### PR TITLE
Feat 스페이스 생성 api

### DIFF
--- a/src/main/java/space/space_spring/argument_resolver/jwtLogin/JwtLoginAuth.java
+++ b/src/main/java/space/space_spring/argument_resolver/jwtLogin/JwtLoginAuth.java
@@ -1,0 +1,11 @@
+package space.space_spring.argument_resolver.jwtLogin;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JwtLoginAuth {
+}

--- a/src/main/java/space/space_spring/argument_resolver/jwtLogin/JwtLoginAuthHandlerArgumentResolver.java
+++ b/src/main/java/space/space_spring/argument_resolver/jwtLogin/JwtLoginAuthHandlerArgumentResolver.java
@@ -1,0 +1,25 @@
+package space.space_spring.argument_resolver.jwtLogin;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class JwtLoginAuthHandlerArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // 일단 parameter의 return value type 을 검사하지는 X
+        return parameter.hasParameterAnnotation(JwtLoginAuth.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        return request.getAttribute("userId");          // jwt를 복호화해서 얻은 userId get
+    }
+}

--- a/src/main/java/space/space_spring/argument_resolver/jwtUserSpace/JwtUserSpaceAuth.java
+++ b/src/main/java/space/space_spring/argument_resolver/jwtUserSpace/JwtUserSpaceAuth.java
@@ -1,4 +1,4 @@
-package space.space_spring.argument_resolver;
+package space.space_spring.argument_resolver.jwtUserSpace;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface JwtPreAuth {
+public @interface JwtUserSpaceAuth {
 }

--- a/src/main/java/space/space_spring/argument_resolver/jwtUserSpace/JwtUserSpaceAuthHandlerArgumentResolver.java
+++ b/src/main/java/space/space_spring/argument_resolver/jwtUserSpace/JwtUserSpaceAuthHandlerArgumentResolver.java
@@ -1,4 +1,4 @@
-package space.space_spring.argument_resolver;
+package space.space_spring.argument_resolver.jwtUserSpace;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
@@ -9,18 +9,17 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
-public class JwtAuthHandlerArgumentResolver implements HandlerMethodArgumentResolver {
-
+public class JwtUserSpaceAuthHandlerArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         // 일단 parameter의 return value type 을 검사하지는 X
-        return parameter.hasParameterAnnotation(JwtPreAuth.class);
+        return parameter.hasParameterAnnotation(JwtUserSpaceAuth.class);
     }
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        return request.getAttribute("userId");          // jwt를 복호화해서 얻은 userId get
+        return request.getAttribute("jwtPayloadDto");          // jwt를 복호화해서 얻은 userId get
     }
 }

--- a/src/main/java/space/space_spring/config/WebConfig.java
+++ b/src/main/java/space/space_spring/config/WebConfig.java
@@ -5,9 +5,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import space.space_spring.argument_resolver.JwtAuthHandlerArgumentResolver;
-import space.space_spring.interceptor.JwtAuthInterceptor;
-import space.space_spring.jwt.JwtProvider;
+import space.space_spring.argument_resolver.jwtLogin.JwtLoginAuthHandlerArgumentResolver;
+import space.space_spring.argument_resolver.jwtUserSpace.JwtUserSpaceAuthHandlerArgumentResolver;
+import space.space_spring.interceptor.jwtLogin.JwtLoginAuthInterceptor;
+import space.space_spring.interceptor.jwtUserSpace.JwtUserSpaceAuthInterceptor;
 
 import java.util.List;
 
@@ -15,18 +16,26 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final JwtAuthInterceptor jwtAuthInterceptor;
-    private final JwtAuthHandlerArgumentResolver authHandlerArgumentResolver;
+    private final JwtLoginAuthInterceptor jwtLoginAuthInterceptor;
+    private final JwtUserSpaceAuthInterceptor jwtUserSpaceAuthInterceptor;
+
+    private final JwtLoginAuthHandlerArgumentResolver jwtLoginAuthHandlerArgumentResolver;
+    private final JwtUserSpaceAuthHandlerArgumentResolver jwtUserSpaceAuthHandlerArgumentResolver;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(jwtAuthInterceptor)
+        registry.addInterceptor(jwtLoginAuthInterceptor)
                 .order(1)
-                .addPathPatterns("/space/**", "/test/**");          // interceptor 적용되야하는 url enum으로 만들어서 여기에 달면 될듯
+                .addPathPatterns("/space/**", "/test/**");
+
+        registry.addInterceptor(jwtUserSpaceAuthInterceptor)
+                .order(2)
+                .addPathPatterns("/test111/**");          // interceptor 적용되야하는 url enum으로 만들어서 여기에 달면 될듯
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
-        argumentResolvers.add(authHandlerArgumentResolver);
+        argumentResolvers.add(jwtLoginAuthHandlerArgumentResolver);
+        argumentResolvers.add(jwtUserSpaceAuthHandlerArgumentResolver);
     }
 }

--- a/src/main/java/space/space_spring/controller/SpaceController.java
+++ b/src/main/java/space/space_spring/controller/SpaceController.java
@@ -1,0 +1,35 @@
+package space.space_spring.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import space.space_spring.argument_resolver.JwtPreAuth;
+import space.space_spring.dto.space.PostSpaceCreateRequest;
+import space.space_spring.dto.space.PostSpaceCreateResponse;
+
+import space.space_spring.exception.SpaceException;
+import space.space_spring.response.BaseResponse;
+import space.space_spring.service.SpaceService;
+
+import static space.space_spring.response.status.BaseExceptionResponseStatus.INVALID_SPACE_CREATE;
+import static space.space_spring.util.BindingResultUtils.getErrorMessage;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/space")
+public class SpaceController {
+
+    private final SpaceService spaceService;
+
+    @PostMapping("/create")
+    public BaseResponse<PostSpaceCreateResponse> createSpace(@JwtPreAuth Long userId, PostSpaceCreateRequest postSpaceCreateRequest, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            throw new SpaceException(INVALID_SPACE_CREATE, getErrorMessage(bindingResult));
+        }
+
+        return new BaseResponse<>(spaceService.createSpace(userId, postSpaceCreateRequest));
+    }
+
+}

--- a/src/main/java/space/space_spring/controller/SpaceController.java
+++ b/src/main/java/space/space_spring/controller/SpaceController.java
@@ -2,7 +2,9 @@ package space.space_spring.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import space.space_spring.argument_resolver.JwtPreAuth;
@@ -24,7 +26,7 @@ public class SpaceController {
     private final SpaceService spaceService;
 
     @PostMapping("/create")
-    public BaseResponse<PostSpaceCreateResponse> createSpace(@JwtPreAuth Long userId, PostSpaceCreateRequest postSpaceCreateRequest, BindingResult bindingResult) {
+    public BaseResponse<PostSpaceCreateResponse> createSpace(@JwtPreAuth Long userId, @Validated @RequestBody PostSpaceCreateRequest postSpaceCreateRequest, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             throw new SpaceException(INVALID_SPACE_CREATE, getErrorMessage(bindingResult));
         }

--- a/src/main/java/space/space_spring/controller/SpaceController.java
+++ b/src/main/java/space/space_spring/controller/SpaceController.java
@@ -1,5 +1,6 @@
 package space.space_spring.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
@@ -7,10 +8,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import space.space_spring.argument_resolver.JwtPreAuth;
+import space.space_spring.argument_resolver.jwtLogin.JwtLoginAuth;
+import space.space_spring.argument_resolver.jwtUserSpace.JwtUserSpaceAuth;
+import space.space_spring.dto.jwt.JwtPayloadDto;
 import space.space_spring.dto.space.PostSpaceCreateRequest;
 import space.space_spring.dto.space.PostSpaceCreateResponse;
 
+import space.space_spring.dto.space.SpaceCreateDto;
 import space.space_spring.exception.SpaceException;
 import space.space_spring.response.BaseResponse;
 import space.space_spring.service.SpaceService;
@@ -26,12 +30,16 @@ public class SpaceController {
     private final SpaceService spaceService;
 
     @PostMapping("/create")
-    public BaseResponse<PostSpaceCreateResponse> createSpace(@JwtPreAuth Long userId, @Validated @RequestBody PostSpaceCreateRequest postSpaceCreateRequest, BindingResult bindingResult) {
+    public BaseResponse<PostSpaceCreateResponse> createSpace(@JwtLoginAuth Long userId, @Validated @RequestBody PostSpaceCreateRequest postSpaceCreateRequest, BindingResult bindingResult, HttpServletResponse response) {
         if (bindingResult.hasErrors()) {
             throw new SpaceException(INVALID_SPACE_CREATE, getErrorMessage(bindingResult));
         }
 
-        return new BaseResponse<>(spaceService.createSpace(userId, postSpaceCreateRequest));
+        SpaceCreateDto spaceCreateDto = spaceService.createSpace(userId, postSpaceCreateRequest);
+        String jwtUserSpace = spaceCreateDto.getJwtUserSpace();
+        response.setHeader("Authorization", "Bearer " + jwtUserSpace);
+
+        return new BaseResponse<>(new PostSpaceCreateResponse(spaceCreateDto.getSpaceId()));
     }
 
 }

--- a/src/main/java/space/space_spring/controller/TestController.java
+++ b/src/main/java/space/space_spring/controller/TestController.java
@@ -3,7 +3,9 @@ package space.space_spring.controller;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-import space.space_spring.argument_resolver.JwtPreAuth;
+import space.space_spring.argument_resolver.jwtLogin.JwtLoginAuth;
+import space.space_spring.argument_resolver.jwtUserSpace.JwtUserSpaceAuth;
+import space.space_spring.dto.jwt.JwtPayloadDto;
 import space.space_spring.response.BaseResponse;
 
 @RestController
@@ -16,8 +18,14 @@ public class TestController {
     }
 
     @GetMapping("/test/jwt")
-    public BaseResponse<String> jwtTest(@JwtPreAuth Long userId) {
+    public BaseResponse<String> jwtLoginTest(@JwtLoginAuth Long userId) {
         log.info("userId = {}", userId);
-        return new BaseResponse<>("jwt test 성공");
+        return new BaseResponse<>("jwt login test 성공");
+    }
+
+    @GetMapping("/test111")
+    public BaseResponse<String> jwtUserSpaceTest(@JwtUserSpaceAuth JwtPayloadDto jwtPayloadDto) {
+        log.info("jwtPayloadDto = {}", jwtPayloadDto);
+        return new BaseResponse<>("jwt user space test 성공");
     }
 }

--- a/src/main/java/space/space_spring/controller/UserController.java
+++ b/src/main/java/space/space_spring/controller/UserController.java
@@ -9,15 +9,15 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import space.space_spring.dto.PostUserLoginRequest;
-import space.space_spring.dto.PostUserLoginResponse;
-import space.space_spring.dto.PostUserSignupRequest;
-import space.space_spring.dto.PostUserSignupResponse;
+import space.space_spring.dto.user.PostUserLoginRequest;
+import space.space_spring.dto.user.PostUserLoginResponse;
+import space.space_spring.dto.user.PostUserSignupRequest;
+import space.space_spring.dto.user.PostUserSignupResponse;
 import space.space_spring.exception.UserException;
 import space.space_spring.response.BaseResponse;
 import space.space_spring.service.UserService;
 
-import static space.space_spring.response.status.BaseExceptionResponseStatus.INVALID_USER_VALUE;
+import static space.space_spring.response.status.BaseExceptionResponseStatus.*;
 import static space.space_spring.util.BindingResultUtils.getErrorMessage;
 
 @Slf4j
@@ -34,7 +34,7 @@ public class UserController {
     @PostMapping("/signup")
     public BaseResponse<PostUserSignupResponse> signup(@Validated @RequestBody PostUserSignupRequest postUserSignupRequest, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
-            throw new UserException(INVALID_USER_VALUE, getErrorMessage(bindingResult));
+            throw new UserException(INVALID_USER_SIGNUP, getErrorMessage(bindingResult));
         }
         return new BaseResponse<>(userService.signup(postUserSignupRequest));
     }
@@ -45,7 +45,7 @@ public class UserController {
     @PostMapping("/login")
     public BaseResponse<PostUserLoginResponse> login(@Validated @RequestBody PostUserLoginRequest postUserLoginRequest, BindingResult bindingResult, HttpServletResponse response) {
         if (bindingResult.hasErrors()) {
-            throw new UserException(INVALID_USER_VALUE, getErrorMessage(bindingResult));
+            throw new UserException(INVALID_USER_LOGIN, getErrorMessage(bindingResult));
         }
 
         String jwt = userService.login(postUserLoginRequest);

--- a/src/main/java/space/space_spring/controller/UserController.java
+++ b/src/main/java/space/space_spring/controller/UserController.java
@@ -48,8 +48,8 @@ public class UserController {
             throw new UserException(INVALID_USER_LOGIN, getErrorMessage(bindingResult));
         }
 
-        String jwt = userService.login(postUserLoginRequest);
-        response.setHeader("Authorization", "Bearer " + jwt);
+        String jwtLogin = userService.login(postUserLoginRequest);
+        response.setHeader("Authorization", "Bearer " + jwtLogin);
         return new BaseResponse<>(new PostUserLoginResponse("로그인 성공"));
     }
 

--- a/src/main/java/space/space_spring/dao/SpaceDao.java
+++ b/src/main/java/space/space_spring/dao/SpaceDao.java
@@ -3,8 +3,12 @@ package space.space_spring.dao;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
-import space.space_spring.domain.Space;
+import space.space_spring.entity.Space;
+import space.space_spring.entity.User;
+import space.space_spring.entity.UserSpace;
 import space.space_spring.dto.space.PostSpaceCreateRequest;
+
+import static space.space_spring.entity.enumStatus.UserSpaceAuth.MANAGER;
 
 @Repository
 public class SpaceDao {
@@ -12,11 +16,18 @@ public class SpaceDao {
     @PersistenceContext
     private EntityManager em;
 
-    public Long saveSpace(PostSpaceCreateRequest postSpaceCreateRequest) {
+    public Space saveSpace(PostSpaceCreateRequest postSpaceCreateRequest) {
         Space space = new Space();
         space.saveSpace(postSpaceCreateRequest.getSpaceName(), postSpaceCreateRequest.getSpaceProfileImg());
 
         em.persist(space);
-        return space.getSpaceId();
+        return space;
+    }
+
+    public void createUserSpace(User manager, Space saveSpace) {
+        UserSpace userSpace = new UserSpace();
+        userSpace.createUserSpace(manager, saveSpace, MANAGER);
+
+        em.persist(userSpace);
     }
 }

--- a/src/main/java/space/space_spring/dao/SpaceDao.java
+++ b/src/main/java/space/space_spring/dao/SpaceDao.java
@@ -1,0 +1,9 @@
+package space.space_spring.dao;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SpaceDao {
+
+
+}

--- a/src/main/java/space/space_spring/dao/SpaceDao.java
+++ b/src/main/java/space/space_spring/dao/SpaceDao.java
@@ -1,9 +1,22 @@
 package space.space_spring.dao;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
+import space.space_spring.domain.Space;
+import space.space_spring.dto.space.PostSpaceCreateRequest;
 
 @Repository
 public class SpaceDao {
 
+    @PersistenceContext
+    private EntityManager em;
 
+    public Long saveSpace(PostSpaceCreateRequest postSpaceCreateRequest) {
+        Space space = new Space();
+        space.saveSpace(postSpaceCreateRequest.getSpaceName(), postSpaceCreateRequest.getSpaceProfileImg());
+
+        em.persist(space);
+        return space.getSpaceId();
+    }
 }

--- a/src/main/java/space/space_spring/dao/SpaceDao.java
+++ b/src/main/java/space/space_spring/dao/SpaceDao.java
@@ -24,10 +24,11 @@ public class SpaceDao {
         return space;
     }
 
-    public void createUserSpace(User manager, Space saveSpace) {
+    public UserSpace createUserSpace(User manager, Space saveSpace) {
         UserSpace userSpace = new UserSpace();
         userSpace.createUserSpace(manager, saveSpace, MANAGER);
 
         em.persist(userSpace);
+        return userSpace;
     }
 }

--- a/src/main/java/space/space_spring/dao/UserDao.java
+++ b/src/main/java/space/space_spring/dao/UserDao.java
@@ -5,7 +5,7 @@ import jakarta.persistence.NoResultException;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
 import org.springframework.stereotype.Repository;
-import space.space_spring.domain.User;
+import space.space_spring.entity.User;
 import space.space_spring.dto.user.PostUserSignupRequest;
 
 @Repository
@@ -14,12 +14,12 @@ public class UserDao {
     @PersistenceContext
     private EntityManager em;
 
-    public Long saveUser(PostUserSignupRequest postUserSignupRequest) {
+    public User saveUser(PostUserSignupRequest postUserSignupRequest) {
         User user = new User();
         user.saveUser(postUserSignupRequest.getEmail(), postUserSignupRequest.getPassword(), postUserSignupRequest.getUserName());
 
         em.persist(user);
-        return user.getUserId();
+        return user;
     }
 
     public User findUserByEmail(String email) {
@@ -42,5 +42,11 @@ public class UserDao {
         } catch (NoResultException e) {
             return null;
         }
+    }
+
+    public User findUserByUserId(Long userId) {
+        TypedQuery<User> query = em.createQuery("SELECT u FROM User u WHERE u.userId = :userId", User.class);
+        query.setParameter("userId", userId);
+        return query.getSingleResult();
     }
 }

--- a/src/main/java/space/space_spring/dao/UserDao.java
+++ b/src/main/java/space/space_spring/dao/UserDao.java
@@ -6,7 +6,7 @@ import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
 import org.springframework.stereotype.Repository;
 import space.space_spring.domain.User;
-import space.space_spring.dto.PostUserSignupRequest;
+import space.space_spring.dto.user.PostUserSignupRequest;
 
 @Repository
 public class UserDao {

--- a/src/main/java/space/space_spring/domain/Space.java
+++ b/src/main/java/space/space_spring/domain/Space.java
@@ -19,4 +19,11 @@ public class Space extends BaseEntity {
     @Column(name = "space_profile_img")
     @Nullable
     private String spaceProfileImg;
+
+    public void saveSpace(String spaceName, String spaceProfileImg) {
+        this.spaceName = spaceName;
+        this.spaceProfileImg = spaceProfileImg;
+        initializeBaseEntityFields();
+    }
+
 }

--- a/src/main/java/space/space_spring/domain/UserSpace.java
+++ b/src/main/java/space/space_spring/domain/UserSpace.java
@@ -32,11 +32,15 @@ public class UserSpace extends BaseEntity {
     @Nullable
     private String userProfileMsg;
 
+    // 스페이스의 관리자 vs 일반 멤버
     @Column(name = "user_auth")
     private String userAuth;
 
+    // 스페이스 선택화면에서의 배치 순서
     @Column(name = "space_order")
     private int spaceOrder;
+
+
 
 
 }

--- a/src/main/java/space/space_spring/dto/jwt/JwtPayloadDto.java
+++ b/src/main/java/space/space_spring/dto/jwt/JwtPayloadDto.java
@@ -1,0 +1,30 @@
+package space.space_spring.dto.jwt;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class JwtPayloadDto {
+
+    private Long userId;
+
+    private List<JwtUserSpaceAuthDto> userSpaceList = new ArrayList<>();
+
+    public void saveUserIdToJwt(Long userId) {
+        this.userId = userId;
+    }
+
+    public void saveUserSpaceList(List<JwtUserSpaceAuthDto> userSpaceList) {
+        this.userSpaceList = userSpaceList;
+    }
+
+    public void addJwtUserSpaceAuth(JwtUserSpaceAuthDto jwtUserSpaceAuthDto) {
+        this.userSpaceList.add(jwtUserSpaceAuthDto);
+    }
+}

--- a/src/main/java/space/space_spring/dto/jwt/JwtUserSpaceAuthDto.java
+++ b/src/main/java/space/space_spring/dto/jwt/JwtUserSpaceAuthDto.java
@@ -1,0 +1,18 @@
+package space.space_spring.dto.jwt;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@ToString
+public class JwtUserSpaceAuthDto {
+
+    private Map<Long, String> userSpaceAuthMap = new HashMap<>();
+
+    public void saveUserSpaceAuth(Long spaceId, String userSpaceAuth) {
+        userSpaceAuthMap.put(spaceId, userSpaceAuth);
+    }
+}

--- a/src/main/java/space/space_spring/dto/space/PostSpaceCreateRequest.java
+++ b/src/main/java/space/space_spring/dto/space/PostSpaceCreateRequest.java
@@ -1,0 +1,17 @@
+package space.space_spring.dto.space;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PostSpaceCreateRequest {
+
+    @Length(min = 1, max = 10, message = "이름은 10자이내의 문자열이어야 합니다.")
+    private String spaceName;
+
+    private String spaceProfileImg;         // 스페이스 프로필 이미지 (썸네일)
+}

--- a/src/main/java/space/space_spring/dto/space/PostSpaceCreateRequest.java
+++ b/src/main/java/space/space_spring/dto/space/PostSpaceCreateRequest.java
@@ -1,5 +1,6 @@
 package space.space_spring.dto.space;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,7 +12,9 @@ import org.hibernate.validator.constraints.Length;
 public class PostSpaceCreateRequest {
 
     @Length(min = 1, max = 10, message = "이름은 10자이내의 문자열이어야 합니다.")
+    @NotBlank(message = "스페이스 이름은 공백일 수 없습니다.")
     private String spaceName;
 
+    @NotBlank(message = "스페이스 프로필 이미지는 공백일 수 없습니다.")
     private String spaceProfileImg;         // 스페이스 프로필 이미지 (썸네일)
 }

--- a/src/main/java/space/space_spring/dto/space/PostSpaceCreateResponse.java
+++ b/src/main/java/space/space_spring/dto/space/PostSpaceCreateResponse.java
@@ -1,0 +1,11 @@
+package space.space_spring.dto.space;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostSpaceCreateResponse {
+
+    private Long spaceId;
+}

--- a/src/main/java/space/space_spring/dto/space/SpaceCreateDto.java
+++ b/src/main/java/space/space_spring/dto/space/SpaceCreateDto.java
@@ -1,0 +1,12 @@
+package space.space_spring.dto.space;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SpaceCreateDto {
+
+    private Long spaceId;
+    private String jwtUserSpace;
+}

--- a/src/main/java/space/space_spring/dto/user/PostUserLoginRequest.java
+++ b/src/main/java/space/space_spring/dto/user/PostUserLoginRequest.java
@@ -1,5 +1,6 @@
 package space.space_spring.dto.user;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,11 +12,13 @@ import lombok.Setter;
 public class PostUserLoginRequest {
 
     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")     // 이메일 정규표현식 확인 필요함
+    @NotBlank
     private String email;
 
     @Pattern(
             regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,16}$",
             message = "8~16글자의 영문 대/소문자, 숫자, 특수문자가 포함되어야 합니다."
     )
+    @NotBlank
     private String password;
 }

--- a/src/main/java/space/space_spring/dto/user/PostUserLoginRequest.java
+++ b/src/main/java/space/space_spring/dto/user/PostUserLoginRequest.java
@@ -1,4 +1,4 @@
-package space.space_spring.dto;
+package space.space_spring.dto.user;
 
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;

--- a/src/main/java/space/space_spring/dto/user/PostUserLoginResponse.java
+++ b/src/main/java/space/space_spring/dto/user/PostUserLoginResponse.java
@@ -1,4 +1,4 @@
-package space.space_spring.dto;
+package space.space_spring.dto.user;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/space/space_spring/dto/user/PostUserSignupRequest.java
+++ b/src/main/java/space/space_spring/dto/user/PostUserSignupRequest.java
@@ -1,4 +1,4 @@
-package space.space_spring.dto;
+package space.space_spring.dto.user;
 
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;

--- a/src/main/java/space/space_spring/dto/user/PostUserSignupRequest.java
+++ b/src/main/java/space/space_spring/dto/user/PostUserSignupRequest.java
@@ -1,5 +1,6 @@
 package space.space_spring.dto.user;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,14 +15,17 @@ import org.hibernate.validator.constraints.Length;
 public class PostUserSignupRequest {
 
     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식에 맞지 않습니다.")     // 이메일 정규표현식 확인 필요함
+    @NotBlank
     private String email;
 
     @Pattern(
             regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,16}$",
             message = "8~16글자의 영문 대/소문자, 숫자, 특수문자가 포함되어야 합니다."
     )
+    @NotBlank
     private String password;
 
     @Length(min = 1, max = 10, message = "이름은 10자이내의 문자열이어야 합니다.")
+    @NotBlank
     private String userName;
 }

--- a/src/main/java/space/space_spring/dto/user/PostUserSignupResponse.java
+++ b/src/main/java/space/space_spring/dto/user/PostUserSignupResponse.java
@@ -1,4 +1,4 @@
-package space.space_spring.dto;
+package space.space_spring.dto.user;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/space/space_spring/entity/BaseEntity.java
+++ b/src/main/java/space/space_spring/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package space.space_spring.domain;
+package space.space_spring.entity;
 
 import jakarta.persistence.*;
 

--- a/src/main/java/space/space_spring/entity/Space.java
+++ b/src/main/java/space/space_spring/entity/Space.java
@@ -1,6 +1,5 @@
-package space.space_spring.domain;
+package space.space_spring.entity;
 
-import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -17,7 +16,6 @@ public class Space extends BaseEntity {
     private String spaceName;
 
     @Column(name = "space_profile_img")
-    @Nullable
     private String spaceProfileImg;
 
     public void saveSpace(String spaceName, String spaceProfileImg) {

--- a/src/main/java/space/space_spring/entity/User.java
+++ b/src/main/java/space/space_spring/entity/User.java
@@ -1,11 +1,8 @@
-package space.space_spring.domain;
+package space.space_spring.entity;
 
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
-import org.hibernate.validator.constraints.Length;
 
 @Entity
 @Table(name = "Users")

--- a/src/main/java/space/space_spring/entity/UserSpace.java
+++ b/src/main/java/space/space_spring/entity/UserSpace.java
@@ -37,7 +37,7 @@ public class UserSpace extends BaseEntity {
     @Column(name = "user_auth")
     private String userSpaceAuth;
 
-    // 스페이스 선택화면에서의 배치 순서
+    // 스페이스 선택화면에서의 배치 순서 -> 일단 개발 후순위 (계속 0으로 저장)
     @Column(name = "space_order")
     private int spaceOrder;
 

--- a/src/main/java/space/space_spring/entity/UserSpace.java
+++ b/src/main/java/space/space_spring/entity/UserSpace.java
@@ -1,8 +1,9 @@
-package space.space_spring.domain;
+package space.space_spring.entity;
 
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.Getter;
+import space.space_spring.entity.enumStatus.UserSpaceAuth;
 
 @Entity
 @Getter
@@ -34,13 +35,18 @@ public class UserSpace extends BaseEntity {
 
     // 스페이스의 관리자 vs 일반 멤버
     @Column(name = "user_auth")
-    private String userAuth;
+    private String userSpaceAuth;
 
     // 스페이스 선택화면에서의 배치 순서
     @Column(name = "space_order")
     private int spaceOrder;
 
-
+    public void createUserSpace(User user, Space space, UserSpaceAuth userSpaceAuth) {
+        this.user = user;
+        this.space = space;
+        this.userName = user.getUserName();
+        this.userSpaceAuth = userSpaceAuth.getAuth();
+    }
 
 
 }

--- a/src/main/java/space/space_spring/entity/enumStatus/UserSpaceAuth.java
+++ b/src/main/java/space/space_spring/entity/enumStatus/UserSpaceAuth.java
@@ -1,0 +1,15 @@
+package space.space_spring.entity.enumStatus;
+
+import lombok.Getter;
+
+@Getter
+public enum UserSpaceAuth {
+    MANAGER("manager"),
+    NORMAL("normal");
+
+    private String auth;
+
+    UserSpaceAuth(String auth) {
+        this.auth = auth;
+    }
+}

--- a/src/main/java/space/space_spring/exception/SpaceException.java
+++ b/src/main/java/space/space_spring/exception/SpaceException.java
@@ -1,0 +1,21 @@
+package space.space_spring.exception;
+
+import lombok.Getter;
+import space.space_spring.response.status.ResponseStatus;
+
+@Getter
+public class SpaceException extends RuntimeException {
+
+    private final ResponseStatus exceptionStatus;
+
+    public SpaceException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public SpaceException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+
+}

--- a/src/main/java/space/space_spring/interceptor/jwtLogin/JwtLoginAuthInterceptor.java
+++ b/src/main/java/space/space_spring/interceptor/jwtLogin/JwtLoginAuthInterceptor.java
@@ -1,0 +1,59 @@
+package space.space_spring.interceptor.jwtLogin;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import space.space_spring.exception.jwt.bad_request.JwtNoTokenException;
+import space.space_spring.exception.jwt.bad_request.JwtUnsupportedTokenException;
+import space.space_spring.exception.jwt.unauthorized.JwtExpiredTokenException;
+import space.space_spring.jwt.JwtLoginProvider;
+
+import static space.space_spring.response.status.BaseExceptionResponseStatus.*;
+
+@Component
+@RequiredArgsConstructor
+public class JwtLoginAuthInterceptor implements HandlerInterceptor{
+
+    private static final String JWT_TOKEN_PREFIX = "Bearer ";
+
+    private final JwtLoginProvider jwtLoginProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String accessToken = resolveAccessToken(request);
+        validateAccessToken(accessToken);
+
+        // jwt에서 userId get
+        Long userIdFromToken = jwtLoginProvider.getUserIdFromToken(accessToken);
+        request.setAttribute("userId", userIdFromToken);
+
+        return true;
+    }
+
+    private void validateAccessToken(String accessToken) {
+        if (jwtLoginProvider.isExpiredToken(accessToken)) {
+            throw new JwtExpiredTokenException(EXPIRED_TOKEN);
+        }
+
+    }
+
+    private String resolveAccessToken(HttpServletRequest request) {
+        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+        validateToken(token);
+        return token.substring(JWT_TOKEN_PREFIX.length());
+    }
+
+    private void validateToken(String token) {
+        if (token == null) {
+            throw new JwtNoTokenException(TOKEN_NOT_FOUND);
+        }
+        if (!token.startsWith(JWT_TOKEN_PREFIX)) {
+            throw new JwtUnsupportedTokenException(UNSUPPORTED_TOKEN_TYPE);
+        }
+    }
+
+
+}

--- a/src/main/java/space/space_spring/interceptor/jwtUserSpace/JwtUserSpaceAuthInterceptor.java
+++ b/src/main/java/space/space_spring/interceptor/jwtUserSpace/JwtUserSpaceAuthInterceptor.java
@@ -1,4 +1,4 @@
-package space.space_spring.interceptor;
+package space.space_spring.interceptor.jwtUserSpace;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-import space.space_spring.jwt.JwtProvider;
+import space.space_spring.dto.jwt.JwtPayloadDto;
+import space.space_spring.jwt.JwtUserSpaceProvider;
 import space.space_spring.exception.jwt.unauthorized.JwtExpiredTokenException;
 import space.space_spring.exception.jwt.bad_request.JwtNoTokenException;
 import space.space_spring.exception.jwt.bad_request.JwtUnsupportedTokenException;
@@ -15,26 +16,26 @@ import static space.space_spring.response.status.BaseExceptionResponseStatus.*;
 
 @Component
 @RequiredArgsConstructor
-public class JwtAuthInterceptor implements HandlerInterceptor {
+public class JwtUserSpaceAuthInterceptor implements HandlerInterceptor {
 
     private static final String JWT_TOKEN_PREFIX = "Bearer ";
 
-    private final JwtProvider jwtProvider;
+    private final JwtUserSpaceProvider jwtUserSpaceProvider;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String accessToken = resolveAccessToken(request);
         validateAccessToken(accessToken);
 
-        // jwt에서 userId get
-        Long userId = jwtProvider.getUserIdFromToken(accessToken);
-        request.setAttribute("userId", userId);
+        // jwt에서 JwtPayloadDto get
+        JwtPayloadDto jwtPayloadDto = jwtUserSpaceProvider.getJwtPayloadDtoFromToken(accessToken);
+        request.setAttribute("jwtPayloadDto", jwtPayloadDto);
 
         return true;
     }
 
     private void validateAccessToken(String accessToken) {
-        if (jwtProvider.isExpiredToken(accessToken)) {
+        if (jwtUserSpaceProvider.isExpiredToken(accessToken)) {
             throw new JwtExpiredTokenException(EXPIRED_TOKEN);
         }
 

--- a/src/main/java/space/space_spring/jwt/JwtLoginProvider.java
+++ b/src/main/java/space/space_spring/jwt/JwtLoginProvider.java
@@ -5,42 +5,45 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import space.space_spring.entity.User;
+import space.space_spring.exception.jwt.bad_request.JwtUnsupportedTokenException;
 import space.space_spring.exception.jwt.unauthorized.JwtInvalidTokenException;
 import space.space_spring.exception.jwt.unauthorized.JwtMalformedTokenException;
-import space.space_spring.exception.jwt.bad_request.JwtUnsupportedTokenException;
 
 import java.util.Date;
 
 import static space.space_spring.response.status.BaseExceptionResponseStatus.*;
 
-@Component
 @Slf4j
-public class JwtProvider {
-
-    @Value("${secret.jwt-secret-key}")
-    private String JWT_SECRET_KEY;
+@Component
+public class JwtLoginProvider {
+    @Value("${secret.jwt-login-secret-key}")
+    private String JWT_LOGIN_SECRET_KEY;
 
     @Value("${secret.jwt-expired-in}")
     private Long JWT_EXPIRED_IN;
 
+
     public String generateToken(User user) {
-        Claims claims = Jwts.claims().setSubject(user.getEmail());
+//        Claims claims = Jwts.claims().setSubject(jwtPayloadDto.getUserId().toString());
+
         Date now = new Date();
         Date expiration = new Date(now.getTime() + JWT_EXPIRED_IN);
 
+        Long userId = user.getUserId();
+
         return Jwts.builder()
-                .setClaims(claims)
+//                .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(expiration)
-                .claim("userId", user.getUserId())
-                .signWith(SignatureAlgorithm.HS256, JWT_SECRET_KEY)
+                .claim("userId", userId)
+                .signWith(SignatureAlgorithm.HS256, JWT_LOGIN_SECRET_KEY)
                 .compact();
     }
 
     public boolean isExpiredToken(String accessToken) {
         try {
             Jws<Claims> claims = Jwts.parserBuilder()
-                    .setSigningKey(JWT_SECRET_KEY).build()
+                    .setSigningKey(JWT_LOGIN_SECRET_KEY).build()
                     .parseClaimsJws(accessToken);
             return claims.getBody().getExpiration().before(new Date());
 
@@ -62,11 +65,11 @@ public class JwtProvider {
     public Long getUserIdFromToken(String accessToken) {
         try {
             Jws<Claims> claims = Jwts.parserBuilder()
-                    .setSigningKey(JWT_SECRET_KEY).build()
+                    .setSigningKey(JWT_LOGIN_SECRET_KEY).build()
                     .parseClaimsJws(accessToken);
             return claims.getBody().get("userId", Long.class);
         } catch (JwtException e) {
-            log.error("[JwtTokenProvider.getUserIdFromToken]", e);
+            log.error("[JwtTokenProvider.getJwtPayloadDtoFromToken]", e);
             throw e;
         }
     }

--- a/src/main/java/space/space_spring/jwt/JwtProvider.java
+++ b/src/main/java/space/space_spring/jwt/JwtProvider.java
@@ -4,7 +4,7 @@ import io.jsonwebtoken.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import space.space_spring.domain.User;
+import space.space_spring.entity.User;
 import space.space_spring.exception.jwt.unauthorized.JwtInvalidTokenException;
 import space.space_spring.exception.jwt.unauthorized.JwtMalformedTokenException;
 import space.space_spring.exception.jwt.bad_request.JwtUnsupportedTokenException;

--- a/src/main/java/space/space_spring/jwt/JwtUserSpaceProvider.java
+++ b/src/main/java/space/space_spring/jwt/JwtUserSpaceProvider.java
@@ -1,0 +1,106 @@
+package space.space_spring.jwt;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import space.space_spring.dto.jwt.JwtPayloadDto;
+import space.space_spring.dto.jwt.JwtUserSpaceAuthDto;
+import space.space_spring.exception.jwt.unauthorized.JwtInvalidTokenException;
+import space.space_spring.exception.jwt.unauthorized.JwtMalformedTokenException;
+import space.space_spring.exception.jwt.bad_request.JwtUnsupportedTokenException;
+
+import java.util.Date;
+import java.util.List;
+
+import static space.space_spring.response.status.BaseExceptionResponseStatus.*;
+
+@Component
+@Slf4j
+public class JwtUserSpaceProvider {
+
+    @Value("${secret.jwt-user-space-secret-key}")
+    private String JWT_USER_SPACE_SECRET_KEY;
+
+    @Value("${secret.jwt-expired-in}")
+    private Long JWT_EXPIRED_IN;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public String generateToken(JwtPayloadDto jwtPayloadDto) {
+//        Claims claims = Jwts.claims().setSubject(jwtPayloadDto.getUserId().toString());
+
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + JWT_EXPIRED_IN);
+
+        Long userId = jwtPayloadDto.getUserId();
+        List<JwtUserSpaceAuthDto> userSpaceList = jwtPayloadDto.getUserSpaceList();
+        String userSpaceListToJson = null;
+        try {
+            userSpaceListToJson = objectMapper.writeValueAsString(userSpaceList);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to convert userSpaceList to json", e);
+        }
+
+        return Jwts.builder()
+//                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .claim("userId", userId)
+                .claim("userSpaceList", userSpaceListToJson)
+                .signWith(SignatureAlgorithm.HS256, JWT_USER_SPACE_SECRET_KEY)
+                .compact();
+
+    }
+
+    public boolean isExpiredToken(String accessToken) {
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(JWT_USER_SPACE_SECRET_KEY).build()
+                    .parseClaimsJws(accessToken);
+            return claims.getBody().getExpiration().before(new Date());
+
+        } catch (ExpiredJwtException e) {
+            return true;
+
+        } catch (UnsupportedJwtException e) {
+            throw new JwtUnsupportedTokenException(UNSUPPORTED_TOKEN_TYPE);
+        } catch (MalformedJwtException e) {
+            throw new JwtMalformedTokenException(MALFORMED_TOKEN);
+        } catch (IllegalArgumentException e) {
+            throw new JwtInvalidTokenException(INVALID_TOKEN);
+        } catch (JwtException e) {
+            log.error("[JwtTokenProvider.validateAccessToken]", e);
+            throw e;
+        }
+    }
+
+    public JwtPayloadDto getJwtPayloadDtoFromToken(String accessToken) {
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(JWT_USER_SPACE_SECRET_KEY).build()
+                    .parseClaimsJws(accessToken);
+
+            Long userId = claims.getBody().get("userId", Long.class);
+            String userSpaceListToJson = claims.getBody().get("userSpaceList", String.class);
+            List<JwtUserSpaceAuthDto> userSpaceList = null;
+            try {
+                userSpaceList = objectMapper.readValue(userSpaceListToJson,
+                        objectMapper.getTypeFactory().constructCollectionType(List.class, JwtUserSpaceAuthDto.class));
+            } catch (JsonProcessingException e) {
+                log.error("Failed to convert json to userSpaceList", e);
+            }
+
+            JwtPayloadDto jwtPayloadDto = new JwtPayloadDto();
+            jwtPayloadDto.saveUserIdToJwt(userId);
+            jwtPayloadDto.saveUserSpaceList(userSpaceList);
+
+            return jwtPayloadDto;
+        } catch (JwtException e) {
+            log.error("[JwtTokenProvider.getJwtPayloadDtoFromToken]", e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
@@ -40,13 +40,37 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     /**
      * 5000: User 오류
      */
-    INVALID_USER_VALUE(5000, HttpStatus.BAD_REQUEST.value(), "회원가입 요청에서 잘못된 값이 존재합니다."),
+    INVALID_USER_SIGNUP(5000, HttpStatus.BAD_REQUEST.value(), "회원가입 요청에서 잘못된 값이 존재합니다."),
     DUPLICATE_EMAIL(5001, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 이메일입니다."),
     DUPLICATE_NICKNAME(5002, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 닉네임입니다."),
     USER_NOT_FOUND(4003, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 회원입니다."),
     PASSWORD_NO_MATCH(4004, HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
     INVALID_USER_STATUS(4005, HttpStatus.BAD_REQUEST.value(), "잘못된 회원 status 값입니다."),
-    EMAIL_NOT_FOUND(4006, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 이메일입니다.");
+    EMAIL_NOT_FOUND(4006, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 이메일입니다."),
+    INVALID_USER_LOGIN(4007, HttpStatus.BAD_REQUEST.value(), "로그인 요청에서 잘못된 값이 존재합니다."),
+
+    /**
+     * 6000: Space 오류
+     */
+    INVALID_SPACE_CREATE(6000, HttpStatus.BAD_REQUEST.value(), "스페이스 생성 요청에서 잘못된 값이 존재합니다."),
+    safd(6001, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 이메일입니다."),
+    adff(6002, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 닉네임입니다."),
+    baab(6003, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 회원입니다."),
+    nff(6004, HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
+    gnf(6005, HttpStatus.BAD_REQUEST.value(), "잘못된 회원 status 값입니다."),
+    fb(6006, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 이메일입니다."),
+
+
+    /**
+     * 7000:  오류
+     */
+    A(7000, HttpStatus.BAD_REQUEST.value(), "회원가입 요청에서 잘못된 값이 존재합니다."),
+    B(7001, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 이메일입니다."),
+    C(7002, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 닉네임입니다."),
+    D(7003, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 회원입니다."),
+    E(7004, HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
+    F(7005, HttpStatus.BAD_REQUEST.value(), "잘못된 회원 status 값입니다."),
+    G(7006, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 이메일입니다.");
 
     private final int code;
     private final int status;

--- a/src/main/java/space/space_spring/service/SpaceService.java
+++ b/src/main/java/space/space_spring/service/SpaceService.java
@@ -2,7 +2,11 @@ package space.space_spring.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import space.space_spring.dao.SpaceDao;
+import space.space_spring.dao.UserDao;
+import space.space_spring.entity.Space;
+import space.space_spring.entity.User;
 import space.space_spring.dto.space.PostSpaceCreateRequest;
 import space.space_spring.dto.space.PostSpaceCreateResponse;
 
@@ -11,17 +15,21 @@ import space.space_spring.dto.space.PostSpaceCreateResponse;
 public class SpaceService {
 
     private final SpaceDao spaceDao;
+    private final UserDao userDao;
 
+    @Transactional
     public PostSpaceCreateResponse createSpace(Long userId, PostSpaceCreateRequest postSpaceCreateRequest) {
 
         // TODO 1. 스페이스 생성 정보 db insert
-        Long spaceId = spaceDao.saveSpace(postSpaceCreateRequest);
+        Space saveSpace = spaceDao.saveSpace(postSpaceCreateRequest);
 
         // TODO 2. 유저_스페이스 매핑 정보 db insert
-
+        User manager = userDao.findUserByUserId(userId);
+        spaceDao.createUserSpace(manager, saveSpace);
 
         // TODO 3. jwt에 space 정보 추가
 
-        return new PostSpaceCreateResponse(spaceId);
+
+        return new PostSpaceCreateResponse(saveSpace.getSpaceId());
     }
 }

--- a/src/main/java/space/space_spring/service/SpaceService.java
+++ b/src/main/java/space/space_spring/service/SpaceService.java
@@ -1,0 +1,19 @@
+package space.space_spring.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import space.space_spring.dao.SpaceDao;
+import space.space_spring.dto.space.PostSpaceCreateRequest;
+import space.space_spring.dto.space.PostSpaceCreateResponse;
+
+@Service
+@RequiredArgsConstructor
+public class SpaceService {
+
+    private final SpaceDao spaceDao;
+
+    public PostSpaceCreateResponse createSpace(Long userId, PostSpaceCreateRequest postSpaceCreateRequest) {
+
+
+    }
+}

--- a/src/main/java/space/space_spring/service/SpaceService.java
+++ b/src/main/java/space/space_spring/service/SpaceService.java
@@ -5,10 +5,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import space.space_spring.dao.SpaceDao;
 import space.space_spring.dao.UserDao;
+import space.space_spring.dto.jwt.JwtPayloadDto;
+import space.space_spring.dto.jwt.JwtUserSpaceAuthDto;
+import space.space_spring.dto.space.SpaceCreateDto;
 import space.space_spring.entity.Space;
 import space.space_spring.entity.User;
 import space.space_spring.dto.space.PostSpaceCreateRequest;
 import space.space_spring.dto.space.PostSpaceCreateResponse;
+import space.space_spring.entity.UserSpace;
+import space.space_spring.jwt.JwtUserSpaceProvider;
 
 @Service
 @RequiredArgsConstructor
@@ -16,20 +21,27 @@ public class SpaceService {
 
     private final SpaceDao spaceDao;
     private final UserDao userDao;
+    private final JwtUserSpaceProvider jwtUserSpaceProvider;
 
     @Transactional
-    public PostSpaceCreateResponse createSpace(Long userId, PostSpaceCreateRequest postSpaceCreateRequest) {
+    public SpaceCreateDto createSpace(Long userId, PostSpaceCreateRequest postSpaceCreateRequest) {
 
         // TODO 1. 스페이스 생성 정보 db insert
         Space saveSpace = spaceDao.saveSpace(postSpaceCreateRequest);
 
         // TODO 2. 유저_스페이스 매핑 정보 db insert
         User manager = userDao.findUserByUserId(userId);
-        spaceDao.createUserSpace(manager, saveSpace);
+        UserSpace userSpace = spaceDao.createUserSpace(manager, saveSpace);
 
         // TODO 3. jwt에 space 정보 추가
+        JwtUserSpaceAuthDto jwtUserSpaceAuthDto = new JwtUserSpaceAuthDto();
+        jwtUserSpaceAuthDto.saveUserSpaceAuth(userSpace.getSpace().getSpaceId(), userSpace.getUserSpaceAuth());
 
+        JwtPayloadDto jwtPayloadDto = new JwtPayloadDto();
+        jwtPayloadDto.addJwtUserSpaceAuth(jwtUserSpaceAuthDto);
 
-        return new PostSpaceCreateResponse(saveSpace.getSpaceId());
+        String jwtUserSpace = jwtUserSpaceProvider.generateToken(jwtPayloadDto);
+
+        return new SpaceCreateDto(saveSpace.getSpaceId(), jwtUserSpace);
     }
 }

--- a/src/main/java/space/space_spring/service/SpaceService.java
+++ b/src/main/java/space/space_spring/service/SpaceService.java
@@ -14,6 +14,14 @@ public class SpaceService {
 
     public PostSpaceCreateResponse createSpace(Long userId, PostSpaceCreateRequest postSpaceCreateRequest) {
 
+        // TODO 1. 스페이스 생성 정보 db insert
+        Long spaceId = spaceDao.saveSpace(postSpaceCreateRequest);
 
+        // TODO 2. 유저_스페이스 매핑 정보 db insert
+
+
+        // TODO 3. jwt에 space 정보 추가
+
+        return new PostSpaceCreateResponse(spaceId);
     }
 }

--- a/src/main/java/space/space_spring/service/UserService.java
+++ b/src/main/java/space/space_spring/service/UserService.java
@@ -6,9 +6,9 @@ import org.springframework.transaction.annotation.Transactional;
 import space.space_spring.jwt.JwtProvider;
 import space.space_spring.dao.UserDao;
 import space.space_spring.domain.User;
-import space.space_spring.dto.PostUserLoginRequest;
-import space.space_spring.dto.PostUserSignupRequest;
-import space.space_spring.dto.PostUserSignupResponse;
+import space.space_spring.dto.user.PostUserLoginRequest;
+import space.space_spring.dto.user.PostUserSignupRequest;
+import space.space_spring.dto.user.PostUserSignupResponse;
 import space.space_spring.exception.UserException;
 
 import static space.space_spring.response.status.BaseExceptionResponseStatus.*;

--- a/src/main/java/space/space_spring/service/UserService.java
+++ b/src/main/java/space/space_spring/service/UserService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import space.space_spring.jwt.JwtProvider;
 import space.space_spring.dao.UserDao;
-import space.space_spring.domain.User;
+import space.space_spring.entity.User;
 import space.space_spring.dto.user.PostUserLoginRequest;
 import space.space_spring.dto.user.PostUserSignupRequest;
 import space.space_spring.dto.user.PostUserSignupResponse;
@@ -29,12 +29,12 @@ public class UserService {
 
 
         // TODO 2. 회원정보 db insert
-        Long savedUserId = userDao.saveUser(postUserSignupRequest);
+        User saveUser = userDao.saveUser(postUserSignupRequest);
 
         // TODO 3. JWT 토큰 초기화 (회원가입시에는 토큰 발급 X)
         String jwt = null;
 
-        return new PostUserSignupResponse(savedUserId, jwt);
+        return new PostUserSignupResponse(saveUser.getUserId(), jwt);
     }
 
     private void validateEmail(String email) {

--- a/src/main/java/space/space_spring/service/UserService.java
+++ b/src/main/java/space/space_spring/service/UserService.java
@@ -3,7 +3,9 @@ package space.space_spring.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import space.space_spring.jwt.JwtProvider;
+import space.space_spring.dto.jwt.JwtPayloadDto;
+import space.space_spring.jwt.JwtLoginProvider;
+import space.space_spring.jwt.JwtUserSpaceProvider;
 import space.space_spring.dao.UserDao;
 import space.space_spring.entity.User;
 import space.space_spring.dto.user.PostUserLoginRequest;
@@ -18,7 +20,7 @@ import static space.space_spring.response.status.BaseExceptionResponseStatus.*;
 public class UserService {
 
     private final UserDao userDao;
-    private final JwtProvider jwtProvider;
+    private final JwtLoginProvider jwtLoginProvider;
 
     @Transactional
     public PostUserSignupResponse signup(PostUserSignupRequest postUserSignupRequest) {
@@ -52,12 +54,12 @@ public class UserService {
         validatePassword(userByEmail, postUserLoginRequest.getPassword());
 
         // TODO 3. JWT 발급
-        String jwt = jwtProvider.generateToken(userByEmail);
+        String jwtLogin = jwtLoginProvider.generateToken(userByEmail);
 
         // TODO 4. JWT db에 insert -> db에 저장해야할까??
-        userByEmail.saveJWTtoLoginUser(jwt);
+        userByEmail.saveJWTtoLoginUser(jwtLogin);
 
-        return jwt;
+        return jwtLogin;
     }
 
     private User findUserByEmail(String email) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,14 +11,15 @@ spring:
 
   jpa:
     hibernate:
-          ddl-auto: update          # create : 존재하는 table을 전부 drop했다가 다시 생성 -> 테스트용
+          ddl-auto: create          # create : 존재하는 table을 전부 drop했다가 다시 생성 -> 테스트용
     properties:
       hibernate:
         format_sql: true
         show_sql: true
 
 secret:
-  jwt-secret-key: ${JWT_SECRET_KEY}
+  jwt-login-secret-key: ${JWT_LOGIN_SECRET_KEY}
+  jwt-user-space-secret-key: ${JWT_USER_SPACE_SECRET_KEY}
   jwt-expired-in: ${JWT_EXPIRED_IN}
 
 logging:

--- a/src/test/java/space/space_spring/service/UserServiceTest.java
+++ b/src/test/java/space/space_spring/service/UserServiceTest.java
@@ -1,16 +1,6 @@
 package space.space_spring.service;
 
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
-import org.springframework.transaction.annotation.Transactional;
-import space.space_spring.dao.UserDao;
-import space.space_spring.domain.User;
-import space.space_spring.dto.PostUserSignupRequest;
-import space.space_spring.dto.PostUserSignupResponse;
 
 @SpringBootTest
 class UserServiceTest {


### PR DESCRIPTION
## 📝 요약

이슈 번호 : #12 

## 🔖 변경 사항
스페이스 생성 api 개발
로그인 진행한 유저는 jwt를 발급받아서 스페이스 생성 요청을 보낼 수 있음 -> 로그인 response의 헤더에 있는 jwt를 스페이스 생성 request 헤더에 넣어야 함
스페이스 생성 요청에 대한 response의 헤더에는 새로운 jwt가 발급됨 (이 유저가 해당 스페이스에 속해있음을 알려주는 jwt)
-> 새로 발급되는 jwt에는 userId, <spaceId, 해당 스페이스에서 이 유저의 권한> map의 list 가 payload에 들어있음
-> 이 정보를 가지고 해당 스페이스에 대한 요청을 보낼수 있는 권한을 가지고있는지를 확인할수 있습니다!

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)
1. postMan에서 회원가임 & 로그인 요청을 보내고, 로그인 응답의 헤더에 들어있는 jwt(loginJwt)를 확보 
2. loginJwt를 스페이스 생성 요청의 헤더에 주입
3. 스페이스 생성 응답의 헤더에 들어있는 jwt(UserSpaceJwt)를 확보
4. userSpaceJwt를 test용 요청의 헤더에 주입(test용 요청은 해당 스페이스에 대한 권한을 가진 유저만이 요청을 보낼 수 있도록 확인하기 위한 용도임)
5. 200 ok 뜨는지 확인

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
