### PR TITLE
feat/#15: 웹소켓 연결 api 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'		// p6spy 설정 추가
 	implementation 'org.springframework.boot:spring-boot-starter-validation'		// validation 추가
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'			// webSocket 추가
 
 //JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/space/space_spring/config/WebConfig.java
+++ b/src/main/java/space/space_spring/config/WebConfig.java
@@ -3,6 +3,7 @@ package space.space_spring.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import space.space_spring.argument_resolver.jwtLogin.JwtLoginAuthHandlerArgumentResolver;
@@ -22,6 +23,8 @@ public class WebConfig implements WebMvcConfigurer {
     private final JwtLoginAuthHandlerArgumentResolver jwtLoginAuthHandlerArgumentResolver;
     private final JwtUserSpaceAuthHandlerArgumentResolver jwtUserSpaceAuthHandlerArgumentResolver;
 
+    private static final String DEVELOP_FRONT_ADDRESS = "http://localhost:3000";
+
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtLoginAuthInterceptor)
@@ -38,4 +41,15 @@ public class WebConfig implements WebMvcConfigurer {
         argumentResolvers.add(jwtLoginAuthHandlerArgumentResolver);
         argumentResolvers.add(jwtUserSpaceAuthHandlerArgumentResolver);
     }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(DEVELOP_FRONT_ADDRESS)
+                .allowedMethods("GET", "POST", "PUT", "DELETE")
+                .exposedHeaders("location")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+
 }

--- a/src/main/java/space/space_spring/config/WebSocketConfig.java
+++ b/src/main/java/space/space_spring/config/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package space.space_spring.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // stomp 접속 주소 url = ws://localhost:8080/ws
+        registry.addEndpoint("/ws")
+                .setAllowedOrigins("*");
+//                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 메세지 구독(수신) 요청의 엔드포인트
+        registry.enableSimpleBroker("/sub");
+
+        // 메세지 발행(송신) 요청의 엔드 포인트
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+}

--- a/src/main/java/space/space_spring/config/WebSocketConfig.java
+++ b/src/main/java/space/space_spring/config/WebSocketConfig.java
@@ -20,9 +20,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         // 메세지 구독(수신) 요청의 엔드포인트
-        registry.enableSimpleBroker("/sub");
+        registry.enableSimpleBroker("/topic");
 
         // 메세지 발행(송신) 요청의 엔드 포인트
-        registry.setApplicationDestinationPrefixes("/pub");
+        registry.setApplicationDestinationPrefixes("/app");
     }
 }

--- a/src/main/java/space/space_spring/controller/TestController.java
+++ b/src/main/java/space/space_spring/controller/TestController.java
@@ -1,10 +1,17 @@
 package space.space_spring.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.annotation.SubscribeMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import space.space_spring.argument_resolver.jwtLogin.JwtLoginAuth;
 import space.space_spring.argument_resolver.jwtUserSpace.JwtUserSpaceAuth;
+import space.space_spring.dto.chat.ChatTestRequest;
+import space.space_spring.dto.chat.ChatTestResponse;
 import space.space_spring.dto.jwt.JwtPayloadDto;
 import space.space_spring.response.BaseResponse;
 
@@ -27,5 +34,17 @@ public class TestController {
     public BaseResponse<String> jwtUserSpaceTest(@JwtUserSpaceAuth JwtPayloadDto jwtPayloadDto) {
         log.info("jwtPayloadDto = {}", jwtPayloadDto);
         return new BaseResponse<>("jwt user space test 성공");
+    }
+
+    @MessageMapping("/chat/{spaceChatId}") // {spaceChatId} 채팅방으로 보낸 메세지 매핑
+    @SendTo("/topic/chat/{spaceChatId}") // {spaceChatId} 채팅방을 구독한 곳들로 메세지 전송
+    public ChatTestResponse webSocketTest(@Payload ChatTestRequest chat, @DestinationVariable String spaceChatId) {
+        log.info(spaceChatId + " 채팅방으로 " + chat.getMsg() + " 전송");
+        return ChatTestResponse.of(chat.getMsg());
+    }
+
+    @SubscribeMapping("/topic/chat/{spaceChatId}") // {spaceChatId} 채팅방을 구독
+    public void webSocketTest(@DestinationVariable String spaceChatId) {
+        log.info(spaceChatId + " 채팅방 구독");
     }
 }

--- a/src/main/java/space/space_spring/controller/TestController.java
+++ b/src/main/java/space/space_spring/controller/TestController.java
@@ -38,13 +38,13 @@ public class TestController {
 
     @MessageMapping("/chat/{spaceChatId}") // {spaceChatId} 채팅방으로 보낸 메세지 매핑
     @SendTo("/topic/chat/{spaceChatId}") // {spaceChatId} 채팅방을 구독한 곳들로 메세지 전송
-    public ChatTestResponse webSocketTest(@Payload ChatTestRequest chat, @DestinationVariable String spaceChatId) {
+    public ChatTestResponse sendMsgTest(@Payload ChatTestRequest chat, @DestinationVariable String spaceChatId) {
         log.info(spaceChatId + " 채팅방으로 " + chat.getMsg() + " 전송");
         return ChatTestResponse.of(chat.getMsg());
     }
 
     @SubscribeMapping("/topic/chat/{spaceChatId}") // {spaceChatId} 채팅방을 구독
-    public void webSocketTest(@DestinationVariable String spaceChatId) {
+    public void subscribeTest(@DestinationVariable String spaceChatId) {
         log.info(spaceChatId + " 채팅방 구독");
     }
 }

--- a/src/main/java/space/space_spring/dto/chat/ChatTestRequest.java
+++ b/src/main/java/space/space_spring/dto/chat/ChatTestRequest.java
@@ -1,0 +1,10 @@
+package space.space_spring.dto.chat;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatTestRequest {
+    private String msg;
+}

--- a/src/main/java/space/space_spring/dto/chat/ChatTestResponse.java
+++ b/src/main/java/space/space_spring/dto/chat/ChatTestResponse.java
@@ -1,0 +1,18 @@
+package space.space_spring.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class ChatTestResponse {
+    private String msg;
+
+    public static ChatTestResponse of(String msg) {
+        return ChatTestResponse.builder()
+                .msg(msg)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📝 요약

이슈 번호 : #15 

## 🔖 변경 사항
- config > `WebConfig` 수정 : cors 설정에 web dev address인 http://localhost:3000 추가
- config > `WebSocketConfig` 추가 : 소켓 통신 설정
- dto > chat > `ChatTestReq`, `ChatTestRes` : 테스트를 위한 채팅 메세지 DTO 생성
- controller > `TestController`
  - sendMsgTest : query param의 spaceChatId를 가진 채팅방으로 메시지 발행(전송)
  - subscribeTest : query param의 spaceChatId를 가진 채팅방 구독(수신)

## ✅ 리뷰 요구사항
`/topic` 엔드 포인트로 특정 채팅방을 구독하여 메시지를 수신하고,
`/app` 엔드 포인트로 특정 채팅방에 메시지를 전송합니다
(제 로컬에서 web 환경 구축해서 테스트를 진행해서, 테스트 원하시는 분들은 react 코드 드리겠습니다!)

## 📸 확인 방법 (선택)
https://github.com/user-attachments/assets/a0521733-9627-408c-b4e9-e9122ccbb759


<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
