### PR TITLE
Feat/#34/S3 이미지 저장소 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,10 +40,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'			// webSocket 추가
 
-//JWT
+	//JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	//S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 test {

--- a/src/main/java/space/space_spring/config/S3config.java
+++ b/src/main/java/space/space_spring/config/S3config.java
@@ -1,0 +1,36 @@
+package space.space_spring.config;
+
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 S3Client(){
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey,secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+
+}

--- a/src/main/java/space/space_spring/controller/ImageS3Controller.java
+++ b/src/main/java/space/space_spring/controller/ImageS3Controller.java
@@ -1,0 +1,29 @@
+package space.space_spring.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import space.space_spring.service.S3Uploader;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/image")
+@RequiredArgsConstructor
+public class ImageS3Controller {
+    private final S3Uploader s3Uploader;
+
+    @PostMapping("")
+    public ResponseEntity<String> uploadImage(@RequestParam("file") MultipartFile file) {
+        try {
+            String uploadedFileUrl = s3Uploader.upload(file, "test-image");
+            return ResponseEntity.ok(uploadedFileUrl);
+        } catch (IOException e) {
+            return ResponseEntity.badRequest().body("Failed to upload image: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/space/space_spring/service/S3Uploader.java
+++ b/src/main/java/space/space_spring/service/S3Uploader.java
@@ -1,0 +1,67 @@
+package space.space_spring.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class S3Uploader {
+
+    private final AmazonS3 amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    //MultipartFile을 전달 받아 File로 전환 후 S3 업로드
+    public  String upload(MultipartFile multipartFile, String dirName) throws IOException{// dirName의 디렉토리가 S3 Bucket 내부에 생성됨
+
+        File uploadFile = convert(multipartFile).orElseThrow(()-> new IllegalArgumentException("MultipartFile -> File 전환 실패"));
+        //System.out.p
+        // print("error: multipart file input. cant control");
+        return upload(uploadFile,dirName);
+    }
+    public String upload(File uploadFile, String dirName){
+        String fileName = dirName+"/"+uploadFile.getName();
+        String uploadImageUrl = putS3(uploadFile,fileName);
+
+        removeNewFile(uploadFile);// convert()함수로 인해서 로컬에 생성된 File 삭제 (MultipartFile -> File 전환 하며 로컬에 파일 생성됨)
+        return uploadImageUrl;
+    }
+    // 업로드하기
+    private String putS3(File uploadFile, String fileName){
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+    // 이미지 지우기
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("File delete success");
+            return;
+        }
+        log.info("File delete fail");
+    }
+    private Optional<File> convert(MultipartFile file) throws  IOException {
+        File convertFile = new File(file.getOriginalFilename()); // 업로드한 파일의 이름
+        if(convertFile.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                fos.write(file.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,10 +1,10 @@
 spring:
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:local}
     group:
-      "local": "localRDB, localMongoDB, localJPA, localPort, localSecret, web-mvc"
-      "dev": "devRDB, devMongoDB, devPort, devJPA, devSecret, web-mvc"
-      "prod": "devRDB, devMongoDB, devPort, prodJPA, devSecret, web-mvc"
+      "local": "localRDB, localMongoDB, localS3,localJPA, localPort, localSecret, web-mvc"
+      "dev": "devRDB, devMongoDB, devS3,devPort, devJPA, devSecret, web-mvc"
+      "prod": "devRDB, devMongoDB, devS3,devPort, prodJPA, devSecret, web-mvc"
 ---
 spring:
   config:
@@ -35,6 +35,23 @@ spring:
   data:
     mongodb:
       uri: mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}/${MONGO_DB}
+
+---
+spring:
+  config:
+    activate:
+      on-profile: "devS3"
+cloud:
+  aws:
+    credentials:
+      access-key: ${S3-ACCESS-KEY}
+      secret-key: ${S3-SECRET-KEY}
+    s3:
+      bucket: project-space-image-storage
+    region:
+      static: ap-northeast-2 # 리전 정보(서울)
+    stack:
+      auto: false
 
 ---
 spring:


### PR DESCRIPTION
## 📝 요약
S3에 이미지를 업로드하는 기능을 추가하고 테스트 이미지를 저장할 수 있는 컨트롤러를 추가 했습니다.

이슈 번호 : #34 

## 🔖 변경 사항
S3 연결을 위한 설정 코드 추가 
- application.yml 파일 추가 
- build.gradle에 S3 의존성 추가
- S3 관련 환경변수 추가
 
S3 파일 업로드를 위한 클래스 투가
- S3config
- S3uploader

S3 업로드 기능 테스트 컨트롤러 추가
-ImageS3Controller
## ✅ 리뷰 요구사항


## 📸 확인 방법 (선택)
S3 업로드 테스트
![image](https://github.com/user-attachments/assets/f0357c18-1048-4df3-9c14-e1c600d4f5f3)
form body에 key 이름을 "file"로 설정하고, 이미지를 업로드하면, S3 에 저장된 URL 주소를 응답합니다.

단, S3 관련 환경 변수를 설정해줘야 합니다.

## 확인된 문제
### 에러
업로드 과정에서 문제 발생 시, S3가 아니라 local에 생성된 이미지 파일이 삭제되지 않고 남아있을 수 있습니다.
이 경우, 같은 이름의 파일을 다시 업로드 하면, `"MultipartFile -> File 전환 실패"` 에러 메세지가 발생합니다.
혹시 테스트 과정 중 다른 에러가 나더라도, local에 사진 파일이 삭제 되었는지 확인해주세요.
### 구조 
저장된 이미지 파일을 어떻게 프론트 엔드에서 보여줄지 정해야합니다.
현재는 응답 받은 이미지 주소로 바로 접속 가능합니다.
S3 요금 제도와 서비스 구조를 고려해서 정하면 좋을 것 같아요.


