### PR TITLE
31 스페이스 선택 view api

### DIFF
--- a/src/main/java/space/space_spring/config/InterceptorURL.java
+++ b/src/main/java/space/space_spring/config/InterceptorURL.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public enum InterceptorURL {
     SPACE("/space/**"),
     TEST("/test/**"),
-    SPACE_LIST_FOR_USER("/user/space");
+    SPACE_LIST_FOR_USER("/user/space-choice");
 
     private final String urlPattern;
 

--- a/src/main/java/space/space_spring/controller/UserController.java
+++ b/src/main/java/space/space_spring/controller/UserController.java
@@ -56,7 +56,7 @@ public class UserController {
      * 유저가 속한 스페이스 리스트
      * (유저별 스페이스 선택 뷰)
      */
-    @GetMapping("/space")
+    @GetMapping("/space-choice")
     public BaseResponse<List<GetSpaceInfoForUserResponse>> showUserSpaceList(@JwtLoginAuth Long userId) {
 
         log.info("userId = {}", userId);

--- a/src/main/java/space/space_spring/controller/UserController.java
+++ b/src/main/java/space/space_spring/controller/UserController.java
@@ -57,11 +57,13 @@ public class UserController {
      * (유저별 스페이스 선택 뷰)
      */
     @GetMapping("/space-choice")
-    public BaseResponse<List<GetSpaceInfoForUserResponse>> showUserSpaceList(@JwtLoginAuth Long userId) {
+    public BaseResponse<List<GetSpaceInfoForUserResponse>> showUserSpaceList(@JwtLoginAuth Long userId,
+                                                                             @RequestParam int size,
+                                                                             @RequestParam Long lastUserSpaceId) {
 
         log.info("userId = {}", userId);
 
-        return new BaseResponse<>(userService.getSpaceListForUser(userId));
+        return new BaseResponse<>(userService.getSpaceListForUser(userId, size, lastUserSpaceId));
     }
 
 }

--- a/src/main/java/space/space_spring/controller/UserController.java
+++ b/src/main/java/space/space_spring/controller/UserController.java
@@ -57,7 +57,7 @@ public class UserController {
      * (유저별 스페이스 선택 뷰)
      */
     @GetMapping("/space-choice")
-    public BaseResponse<List<GetSpaceInfoForUserResponse>> showUserSpaceList(@JwtLoginAuth Long userId,
+    public BaseResponse<GetSpaceInfoForUserResponse> showUserSpaceList(@JwtLoginAuth Long userId,
                                                                              @RequestParam int size,
                                                                              @RequestParam Long lastUserSpaceId) {
 

--- a/src/main/java/space/space_spring/dao/UserSpaceDao.java
+++ b/src/main/java/space/space_spring/dao/UserSpaceDao.java
@@ -39,7 +39,7 @@ public class UserSpaceDao {
     }
 
 
-    public List<GetSpaceInfoForUserResponse> getSpaceNameAndProfileImgList(User userByUserId) {
+    public List<GetSpaceInfoForUserResponse> getSpaceNameAndProfileImgList(User userByUserId, int size, Long lastUserSpaceId) {
         String jpql = "SELECT s.spaceName, s.spaceProfileImg " +
                 "FROM UserSpace us JOIN us.space s " +
                 "WHERE us.user = :user";

--- a/src/main/java/space/space_spring/dao/UserSpaceDao.java
+++ b/src/main/java/space/space_spring/dao/UserSpaceDao.java
@@ -66,6 +66,11 @@ public class UserSpaceDao {
             newLastUserSpaceId = userSpaceId;
         }
 
+        // 데이터가 마지막임을 알리기 위해 -1 설정
+        if (results.isEmpty()) {
+            newLastUserSpaceId = -1L;
+        }
+
         return new SpaceChoiceViewDto(responseList, newLastUserSpaceId);
     }
 

--- a/src/main/java/space/space_spring/dto/user/GetSpaceInfoForUserResponse.java
+++ b/src/main/java/space/space_spring/dto/user/GetSpaceInfoForUserResponse.java
@@ -4,11 +4,17 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+import java.util.Map;
+
 @Getter
 @AllArgsConstructor
 public class GetSpaceInfoForUserResponse {
 
-    private String spaceName;
+    private String userName;
 
-    private String spaceImgUrl;
+    private Long lastUserSpaceId;
+
+    private List<Map<String, String>> spaceInfoList;
+
 }

--- a/src/main/java/space/space_spring/dto/user/SpaceChoiceViewDto.java
+++ b/src/main/java/space/space_spring/dto/user/SpaceChoiceViewDto.java
@@ -1,0 +1,15 @@
+package space.space_spring.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class SpaceChoiceViewDto {
+
+    private List<Map<String, String>> spaceNameAndProfileImgList;
+    private Long lastUserSpaceId;
+}

--- a/src/main/java/space/space_spring/service/UserService.java
+++ b/src/main/java/space/space_spring/service/UserService.java
@@ -84,12 +84,12 @@ public class UserService {
     }
 
     @Transactional
-    public List<GetSpaceInfoForUserResponse> getSpaceListForUser(Long userId) {
+    public List<GetSpaceInfoForUserResponse> getSpaceListForUser(Long userId, int size, Long lastUserSpaceId) {
         // TODO 1. userId로 User find
         User userByUserId = findUserByUserId(userId);
 
-        // TODO 2. 특정 유저가 속해있는 모든 스페이스들 정보 return
-        return userSpaceDao.getSpaceNameAndProfileImgList(userByUserId);
+        // TODO 2. 특정 유저가 속해있는 스페이스 정보들을 return -> 무한 스크롤 구현
+        return userSpaceDao.getSpaceNameAndProfileImgList(userByUserId, size, lastUserSpaceId);
     }
 
     private User findUserByUserId(Long userId) {

--- a/src/main/java/space/space_spring/service/UserService.java
+++ b/src/main/java/space/space_spring/service/UserService.java
@@ -5,17 +5,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import space.space_spring.dao.UserSpaceDao;
-import space.space_spring.dto.user.GetSpaceInfoForUserResponse;
+import space.space_spring.dto.user.*;
 import space.space_spring.jwt.JwtLoginProvider;
 import space.space_spring.dao.UserDao;
 import space.space_spring.entity.User;
-import space.space_spring.dto.user.PostUserLoginRequest;
-import space.space_spring.dto.user.PostUserSignupRequest;
-import space.space_spring.dto.user.PostUserSignupResponse;
 import space.space_spring.exception.UserException;
 import space.space_spring.response.BaseResponse;
 
 import java.util.List;
+import java.util.Map;
 
 import static space.space_spring.response.status.BaseExceptionResponseStatus.*;
 
@@ -84,12 +82,18 @@ public class UserService {
     }
 
     @Transactional
-    public List<GetSpaceInfoForUserResponse> getSpaceListForUser(Long userId, int size, Long lastUserSpaceId) {
+    public GetSpaceInfoForUserResponse getSpaceListForUser(Long userId, int size, Long lastUserSpaceId) {
         // TODO 1. userId로 User find
         User userByUserId = findUserByUserId(userId);
 
-        // TODO 2. 특정 유저가 속해있는 스페이스 정보들을 return -> 무한 스크롤 구현
-        return userSpaceDao.getSpaceNameAndProfileImgList(userByUserId, size, lastUserSpaceId);
+        // TODO 2. 특정 유저가 속해있는 스페이스 정보들을 get -> 무한 스크롤 구현
+        SpaceChoiceViewDto spaceChoiceViewDto = userSpaceDao.getSpaceChoiceView(userByUserId, size, lastUserSpaceId);
+
+        // TODO 3. find userName
+        String userName = userByUserId.getUserName();
+
+        // TODO 4. return
+        return new GetSpaceInfoForUserResponse(userName, spaceChoiceViewDto.getLastUserSpaceId(), spaceChoiceViewDto.getSpaceNameAndProfileImgList());
     }
 
     private User findUserByUserId(Long userId) {

--- a/src/main/java/space/space_spring/service/UserService.java
+++ b/src/main/java/space/space_spring/service/UserService.java
@@ -86,7 +86,8 @@ public class UserService {
         // TODO 1. userId로 User find
         User userByUserId = findUserByUserId(userId);
 
-        // TODO 2. user가 속한 스페이스가 없는 경우 -> 예외처리 ?? (현재 lastUserSpaceId가 null & 스페이스 info list는 빈 껍데기로 response가 전달됨)
+        // TODO 2. user가 속한 스페이스가 없는 경우 -> 예외처리 ??
+        // (현재 lastUserSpaceId가 -1 & 스페이스 info list는 빈 껍데기로 response가 전달됨)
         validateSpaceListForUser(userByUserId);
 
         // TODO 3. 특정 유저가 속해있는 스페이스 정보들을 get -> 무한 스크롤 구현

--- a/src/main/java/space/space_spring/service/UserService.java
+++ b/src/main/java/space/space_spring/service/UserService.java
@@ -86,14 +86,22 @@ public class UserService {
         // TODO 1. userId로 User find
         User userByUserId = findUserByUserId(userId);
 
-        // TODO 2. 특정 유저가 속해있는 스페이스 정보들을 get -> 무한 스크롤 구현
+        // TODO 2. user가 속한 스페이스가 없는 경우 -> 예외처리 ?? (현재 lastUserSpaceId가 null & 스페이스 info list는 빈 껍데기로 response가 전달됨)
+        validateSpaceListForUser(userByUserId);
+
+        // TODO 3. 특정 유저가 속해있는 스페이스 정보들을 get -> 무한 스크롤 구현
         SpaceChoiceViewDto spaceChoiceViewDto = userSpaceDao.getSpaceChoiceView(userByUserId, size, lastUserSpaceId);
 
-        // TODO 3. find userName
+        // TODO 4. find userName
         String userName = userByUserId.getUserName();
 
-        // TODO 4. return
+        // TODO 5. return
         return new GetSpaceInfoForUserResponse(userName, spaceChoiceViewDto.getLastUserSpaceId(), spaceChoiceViewDto.getSpaceNameAndProfileImgList());
+    }
+
+    private void validateSpaceListForUser(User userByUserId) {
+        // 프론트 개발자 분들과 상의해서 결정해야할 거 같음
+
     }
 
     private User findUserByUserId(Long userId) {


### PR DESCRIPTION
## 📝 요약
로그인한 유저의 jwt를 포함한 요청을 보내면, 유저가 속한 스페이스 이름 & 썸네일 정보들을 response로 보내주는 api 입니다

무한 스크롤을 구현하기 위해 request에 size, lastUserSpaceId 값을 requestParam으로 전달받고,response에 lastUserSpaceId 값을 추가하였습니다
만약, 더 이상 보여줄 스페이스 목록이 없는 경우에는 response의 lastUserSpaceId 로 -1을 넘겨주게 되어 프론트 단에서 더 이상 유저가 속한 스페이스가 없다는 것을 인지할 수 있습니다.

추후 스페이스 생성 api에서  aws s3에 직접 사진을 업로드하는 기능을 추가한 후, 저장한 사진의 url이 응답으로 잘 전달되는 지 확인해봐야할거 같습니다.

이슈 번호 : #31 

## 🔖 변경 사항
로그인 한 유저만이 보낼 수 있는 요청이므로, 인가처리를 위해 api의 요청 url 인 /user/space-choice 를 InterceptorURL 클래스에 추가하였습니다.

현재는 response로 넘겨줄 스페이스 정보 데이터가 없는 경우, 빈 껍데기를 전송합니다. 추후에 프론트 개발자 분과 상의를 통해 이런 경우 다른 방식으로 response를 넘겨야 할 가능성이 있어, 일단 서비스단에서 코드의 분기처리만 진행하였습니다

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
