### PR TITLE
37 정산 view api

### DIFF
--- a/src/main/java/space/space_spring/controller/PayController.java
+++ b/src/main/java/space/space_spring/controller/PayController.java
@@ -1,0 +1,16 @@
+package space.space_spring.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+import space.space_spring.service.PayService;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class PayController {
+
+    private final PayService payService;
+
+
+}

--- a/src/main/java/space/space_spring/controller/PayController.java
+++ b/src/main/java/space/space_spring/controller/PayController.java
@@ -2,8 +2,21 @@ package space.space_spring.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import space.space_spring.argument_resolver.jwtLogin.JwtLoginAuth;
+import space.space_spring.dto.pay.GetPayViewResponse;
+import space.space_spring.dto.pay.PayReceiveInfoDto;
+import space.space_spring.dto.pay.PayRequestInfoDto;
+import space.space_spring.entity.UserSpace;
+import space.space_spring.response.BaseResponse;
 import space.space_spring.service.PayService;
+import space.space_spring.util.userSpace.UserSpaceUtils;
+
+import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -11,6 +24,26 @@ import space.space_spring.service.PayService;
 public class PayController {
 
     private final PayService payService;
+    private final UserSpaceUtils userSpaceUtils;
 
+    @GetMapping("/space/{spaceId}/pay")
+    public BaseResponse<GetPayViewResponse> showPayListForUser(@JwtLoginAuth Long userId, @PathVariable Long spaceId) {
+        // TODO 1. 유저가 스페이스에 속하는 지 검증
+        validateIsUserInSpace(userId, spaceId);
+
+        // TODO 2. 유저가 요청한 정산 리스트 get
+        List<PayRequestInfoDto> payRequestInfoDtoList = payService.getPayRequestInfoForUser(userId, spaceId);
+
+        // TODO 3. 유저가 요청받은 정산 리스트 get
+        List<PayReceiveInfoDto> payReceiveInfoDtoList = payService.getPayReceiveInfoForUser(userId, spaceId);
+
+        return new BaseResponse<>(new GetPayViewResponse(payRequestInfoDtoList, payReceiveInfoDtoList));
+    }
+
+    private void validateIsUserInSpace(Long userId, Long spaceId) {
+        // 유저가 스페이스에 속할 경우 exception이 터지지 않을 것임
+        // 그렇지 않을 경우, USER_IS_NOT_IN_SPACE 예외가 터질 것임 -> 추후 exception handling 과정 필요
+        userSpaceUtils.isUserInSpace(userId, spaceId);
+    }
 
 }

--- a/src/main/java/space/space_spring/controller/SpaceController.java
+++ b/src/main/java/space/space_spring/controller/SpaceController.java
@@ -38,6 +38,9 @@ public class SpaceController {
         return new BaseResponse<>(spaceService.createSpace(userId, postSpaceCreateRequest));
     }
 
+    /**
+     *  테스트 용
+     */
     @GetMapping("/{spaceId}")
     public BaseResponse<String> getSpaceHome(@JwtLoginAuth Long userId, @PathVariable Long spaceId) {
         Optional<UserSpace> userInSpace = userSpaceUtils.isUserInSpace(userId, spaceId);

--- a/src/main/java/space/space_spring/controller/TestController.java
+++ b/src/main/java/space/space_spring/controller/TestController.java
@@ -1,5 +1,6 @@
 package space.space_spring.controller;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -7,9 +8,11 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.annotation.SubscribeMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import space.space_spring.argument_resolver.jwtLogin.JwtLoginAuth;
 
+import space.space_spring.dao.PayDao;
 import space.space_spring.dto.chat.ChatTestRequest;
 import space.space_spring.dto.chat.ChatTestResponse;
 import space.space_spring.dto.jwt.JwtPayloadDto;

--- a/src/main/java/space/space_spring/controller/UserController.java
+++ b/src/main/java/space/space_spring/controller/UserController.java
@@ -58,8 +58,8 @@ public class UserController {
      */
     @GetMapping("/space-choice")
     public BaseResponse<GetSpaceInfoForUserResponse> showUserSpaceList(@JwtLoginAuth Long userId,
-                                                                             @RequestParam int size,
-                                                                             @RequestParam Long lastUserSpaceId) {
+                                                                       @RequestParam int size,
+                                                                       @RequestParam Long lastUserSpaceId) {
 
         log.info("userId = {}", userId);
 

--- a/src/main/java/space/space_spring/dao/PayDao.java
+++ b/src/main/java/space/space_spring/dao/PayDao.java
@@ -1,0 +1,14 @@
+package space.space_spring.dao;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PayDao {
+
+    @PersistenceContext
+    private EntityManager em;
+
+
+}

--- a/src/main/java/space/space_spring/dao/PayDao.java
+++ b/src/main/java/space/space_spring/dao/PayDao.java
@@ -5,6 +5,7 @@ import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
 import space.space_spring.entity.PayRequest;
 import space.space_spring.entity.PayRequestTarget;
+import space.space_spring.entity.Space;
 import space.space_spring.entity.User;
 
 import java.util.List;
@@ -15,12 +16,14 @@ public class PayDao {
     @PersistenceContext
     private EntityManager em;
 
-    public List<PayRequest> findPayRequestListByUser(User user) {
+    public List<PayRequest> findPayRequestListByUser(User user, Space space) {
+        // 유저가 해당 스페이스에서 요청한 정산 목록만을 select
         // 아직 정산이 완료되지 않은 payRequest 엔티티만 select
-        String jpql = "SELECT pr FROM PayRequest pr WHERE pr.payCreateUser = :user AND pr.isComplete = false";
+        String jpql = "SELECT pr FROM PayRequest pr WHERE pr.payCreateUser = :user AND pr.space = :space AND pr.isComplete = false";
 
         return em.createQuery(jpql, PayRequest.class)
                 .setParameter("user", user)
+                .setParameter("space", space)
                 .getResultList();
     }
 
@@ -34,12 +37,16 @@ public class PayDao {
                 .getResultList();
     }
 
-    public List<PayRequestTarget> findPayRequestTargetListByUser(User userByUserId) {
+    public List<PayRequestTarget> findPayRequestTargetListByUser(User user, Space space) {
+        // 유저가 해당 스페이스에서 요청받은 정산 목록만을 select
         // 유저가 요청받은 정산 중 아직 완료되지 않은 payRequestTarget 엔티티만 select
-        String jpql = "SELECT prt FROM PayRequestTarget prt WHERE prt.targetUserId = :userId AND prt.isComplete = false";
+        String jpql = "SELECT prt FROM PayRequestTarget prt " +
+                "JOIN prt.payRequest pr " +
+                "WHERE prt.targetUserId = :userId AND pr.space = :space AND pr.isComplete = false";
 
         return em.createQuery(jpql, PayRequestTarget.class)
-                .setParameter("userId", userByUserId.getUserId())
+                .setParameter("userId", user.getUserId())
+                .setParameter("space", space)
                 .getResultList();
     }
 

--- a/src/main/java/space/space_spring/dao/PayDao.java
+++ b/src/main/java/space/space_spring/dao/PayDao.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
 import space.space_spring.entity.PayRequest;
+import space.space_spring.entity.PayRequestTarget;
 import space.space_spring.entity.User;
 
 import java.util.List;
@@ -24,5 +25,13 @@ public class PayDao {
     }
 
 
+    public List<PayRequestTarget> findPayRequestTargetList(PayRequest payRequest) {
+        // 해당 정산 요청의 모든 타겟 엔티티를 select
+        String jpql = "SELECT prt FROM PayRequestTarget prt WHERE prt.payRequest = :payRequest";
+
+        return em.createQuery(jpql, PayRequestTarget.class)
+                .setParameter("payRequest", payRequest)
+                .getResultList();
+    }
 
 }

--- a/src/main/java/space/space_spring/dao/PayDao.java
+++ b/src/main/java/space/space_spring/dao/PayDao.java
@@ -25,12 +25,21 @@ public class PayDao {
     }
 
 
-    public List<PayRequestTarget> findPayRequestTargetList(PayRequest payRequest) {
+    public List<PayRequestTarget> findPayRequestTargetListByPayRequest(PayRequest payRequest) {
         // 해당 정산 요청의 모든 타겟 엔티티를 select
         String jpql = "SELECT prt FROM PayRequestTarget prt WHERE prt.payRequest = :payRequest";
 
         return em.createQuery(jpql, PayRequestTarget.class)
                 .setParameter("payRequest", payRequest)
+                .getResultList();
+    }
+
+    public List<PayRequestTarget> findPayRequestTargetListByUser(User userByUserId) {
+        // 유저가 요청받은 정산 중 아직 완료되지 않은 payRequestTarget 엔티티만 select
+        String jpql = "SELECT prt FROM PayRequestTarget prt WHERE prt.targetUserId = :userId AND prt.isComplete = false";
+
+        return em.createQuery(jpql, PayRequestTarget.class)
+                .setParameter("userId", userByUserId.getUserId())
                 .getResultList();
     }
 

--- a/src/main/java/space/space_spring/dao/PayDao.java
+++ b/src/main/java/space/space_spring/dao/PayDao.java
@@ -2,7 +2,9 @@ package space.space_spring.dao;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import org.hibernate.validator.internal.constraintvalidators.bv.AssertFalseValidator;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import space.space_spring.entity.PayRequest;
 import space.space_spring.entity.PayRequestTarget;
 import space.space_spring.entity.Space;

--- a/src/main/java/space/space_spring/dao/PayDao.java
+++ b/src/main/java/space/space_spring/dao/PayDao.java
@@ -3,12 +3,26 @@ package space.space_spring.dao;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
+import space.space_spring.entity.PayRequest;
+import space.space_spring.entity.User;
+
+import java.util.List;
 
 @Repository
 public class PayDao {
 
     @PersistenceContext
     private EntityManager em;
+
+    public List<PayRequest> findPayRequestListByUser(User user) {
+        // 아직 정산이 완료되지 않은 payRequest 엔티티만 select
+        String jpql = "SELECT pr FROM PayRequest pr WHERE pr.payCreateUser = :user AND pr.isComplete = false";
+
+        return em.createQuery(jpql, PayRequest.class)
+                .setParameter("user", user)
+                .getResultList();
+    }
+
 
 
 }

--- a/src/main/java/space/space_spring/dto/pay/GetPayViewResponse.java
+++ b/src/main/java/space/space_spring/dto/pay/GetPayViewResponse.java
@@ -1,0 +1,16 @@
+package space.space_spring.dto.pay;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class GetPayViewResponse {
+
+    private List<PayRequestInfoDto> payRequestInfoDtoList = new ArrayList<>();
+
+    private List<PayReceiveInfoDto> payReceiveInfoDtoList = new ArrayList<>();
+}

--- a/src/main/java/space/space_spring/dto/pay/PayReceiveInfoDto.java
+++ b/src/main/java/space/space_spring/dto/pay/PayReceiveInfoDto.java
@@ -1,0 +1,7 @@
+package space.space_spring.dto.pay;
+
+import lombok.Getter;
+
+@Getter
+public class PayReceiveInfoDto {
+}

--- a/src/main/java/space/space_spring/dto/pay/PayReceiveInfoDto.java
+++ b/src/main/java/space/space_spring/dto/pay/PayReceiveInfoDto.java
@@ -1,7 +1,13 @@
 package space.space_spring.dto.pay;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class PayReceiveInfoDto {
+
+    private String payCreatorName;
+
+    private int requestAmount;
 }

--- a/src/main/java/space/space_spring/dto/pay/PayRequestInfoDto.java
+++ b/src/main/java/space/space_spring/dto/pay/PayRequestInfoDto.java
@@ -1,9 +1,17 @@
 package space.space_spring.dto.pay;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class PayRequestInfoDto {
 
+    private int totalAmount;            // 정산 총 금액
 
+    private int receiveAmount;          // 현재까지 받은 금액
+
+    private int totalTargetNum;         // 정산 요청한 사람 수
+
+    private int receiveTargetNum;       // 그 중, 돈 보낸 사람 수
 }

--- a/src/main/java/space/space_spring/dto/pay/PayRequestInfoDto.java
+++ b/src/main/java/space/space_spring/dto/pay/PayRequestInfoDto.java
@@ -1,0 +1,9 @@
+package space.space_spring.dto.pay;
+
+import lombok.Getter;
+
+@Getter
+public class PayRequestInfoDto {
+
+
+}

--- a/src/main/java/space/space_spring/entity/PayRequest.java
+++ b/src/main/java/space/space_spring/entity/PayRequest.java
@@ -1,0 +1,35 @@
+package space.space_spring.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "Pay_Request")
+public class PayRequest extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "pay_request_id")
+    private Long payRequestId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User payCreateUser;         // 정산을 시작한 유저
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "space_id")
+    private Space space;                // 정산이 이루어지는 스페이스
+
+    @Column(name = "total_price")
+    private int totalPrice;             // 정산의 총 금액
+
+    @Column(name = "pay_request_bank")
+    private String bankName;            // 정산 받을 은행 이름
+
+    @Column(name = "bank_account_num")
+    private String bankAccountNum;      // 정산 받을 은행 계좌번호
+
+    @Column(name = "is_complete")
+    private boolean isComplete;
+}

--- a/src/main/java/space/space_spring/entity/PayRequest.java
+++ b/src/main/java/space/space_spring/entity/PayRequest.java
@@ -32,4 +32,13 @@ public class PayRequest extends BaseEntity {
 
     @Column(name = "is_complete")
     private boolean isComplete;
+
+    public void savePayRequest(User payCreateUser, Space space, int totalAmount, String bankName, String bankAccountNum, boolean isComplete) {
+        this.payCreateUser = payCreateUser;
+        this.space = space;
+        this.totalAmount = totalAmount;
+        this.bankName = bankName;
+        this.bankAccountNum = bankAccountNum;
+        this.isComplete = isComplete;
+    }
 }

--- a/src/main/java/space/space_spring/entity/PayRequest.java
+++ b/src/main/java/space/space_spring/entity/PayRequest.java
@@ -21,8 +21,8 @@ public class PayRequest extends BaseEntity {
     @JoinColumn(name = "space_id")
     private Space space;                // 정산이 이루어지는 스페이스
 
-    @Column(name = "total_price")
-    private int totalPrice;             // 정산의 총 금액
+    @Column(name = "total_amount")
+    private int totalAmount;             // 정산의 총 금액
 
     @Column(name = "pay_request_bank")
     private String bankName;            // 정산 받을 은행 이름

--- a/src/main/java/space/space_spring/entity/PayRequestTarget.java
+++ b/src/main/java/space/space_spring/entity/PayRequestTarget.java
@@ -1,0 +1,29 @@
+package space.space_spring.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import space.space_spring.response.BaseResponse;
+
+@Entity
+@Getter
+public class PayRequestTarget extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "pay_request_target_id")
+    private Long payRequestTargetId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pay_request_id")
+    private PayRequest payRequest;
+
+    @Column(name = "target_user_id")
+    private Long targetUserId;
+
+    @Column(name = "request_amount")
+    private int requestAmount;
+
+    @Column(name = "is_complete")
+    private boolean isComplete;
+
+}

--- a/src/main/java/space/space_spring/entity/PayRequestTarget.java
+++ b/src/main/java/space/space_spring/entity/PayRequestTarget.java
@@ -24,4 +24,11 @@ public class PayRequestTarget extends BaseEntity {
 
     @Column(name = "is_complete")
     private boolean isComplete;
+
+    public void savePayRequestTarget(PayRequest payRequest, Long targetUserId, int requestAmount, boolean isComplete) {
+        this.payRequest = payRequest;
+        this.targetUserId = targetUserId;
+        this.requestAmount = requestAmount;
+        this.isComplete = isComplete;
+    }
 }

--- a/src/main/java/space/space_spring/entity/PayRequestTarget.java
+++ b/src/main/java/space/space_spring/entity/PayRequestTarget.java
@@ -17,12 +17,11 @@ public class PayRequestTarget extends BaseEntity {
     private PayRequest payRequest;
 
     @Column(name = "target_user_id")
-    private Long targetUserId;
+    private Long targetUserId;              // User 객체를 필드로 가지는 것보다 이게 더 낫나??
 
     @Column(name = "request_amount")
     private int requestAmount;
 
     @Column(name = "is_complete")
     private boolean isComplete;
-
 }

--- a/src/main/java/space/space_spring/entity/PayRequestTarget.java
+++ b/src/main/java/space/space_spring/entity/PayRequestTarget.java
@@ -2,7 +2,6 @@ package space.space_spring.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
-import space.space_spring.response.BaseResponse;
 
 @Entity
 @Getter

--- a/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
@@ -53,7 +53,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
      * 6000: Space 오류
      */
     INVALID_SPACE_CREATE(6000, HttpStatus.BAD_REQUEST.value(), "스페이스 생성 요청에서 잘못된 값이 존재합니다."),
-    safd(6001, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 이메일입니다."),
+    SPACE_NOT_FOUND(6001, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 스페이스입니다."),
     adff(6002, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 닉네임입니다."),
     baab(6003, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 회원입니다."),
     nff(6004, HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),

--- a/src/main/java/space/space_spring/service/PayService.java
+++ b/src/main/java/space/space_spring/service/PayService.java
@@ -7,7 +7,9 @@ import space.space_spring.dto.pay.PayReceiveInfoDto;
 import space.space_spring.dto.pay.PayRequestInfoDto;
 import space.space_spring.entity.PayRequest;
 import space.space_spring.entity.PayRequestTarget;
+import space.space_spring.entity.Space;
 import space.space_spring.entity.User;
+import space.space_spring.util.space.SpaceUtils;
 import space.space_spring.util.user.UserUtils;
 
 import java.util.ArrayList;
@@ -19,15 +21,19 @@ public class PayService {
 
     private final PayDao payDao;
     private final UserUtils userUtils;
+    private final SpaceUtils spaceUtils;
 
     public List<PayRequestInfoDto> getPayRequestInfoForUser(Long userId, Long spaceId) {
         // TODO 1. userId에 해당하는 user find
         User userByUserId = userUtils.findUserByUserId(userId);
+        
+        // TODO 2. spaceId에 해당하는 space find
+        Space spaceBySpaceId = spaceUtils.findSpaceBySpaceId(spaceId);
 
-        // TODO 2. 유저가 요청한 정산 중 진행 중인 정산 리스트 select
-        List<PayRequest> payRequestListByUser = payDao.findPayRequestListByUser(userByUserId);
+        // TODO 3. 유저가 요청한 정산 중 진행 중인 정산 리스트 select
+        List<PayRequest> payRequestListByUser = payDao.findPayRequestListByUser(userByUserId, spaceBySpaceId);
 
-        // TODO 3. return 타입 구성
+        // TODO 4. return 타입 구성
         // 3-1. 각 payRequest 에 해당하는 모든 payRequestTarget 을 loop로 돌면서 데이터 수집
         List<PayRequestInfoDto> payRequestInfoDtoList = new ArrayList<>();
 
@@ -60,10 +66,13 @@ public class PayService {
         // TODO 1. userId에 해당하는 유저 find
         User userByUserId = userUtils.findUserByUserId(userId);
 
-        // TODO 2. 유저가 요청받은 정산 중 진행 중인 정산 리스트 select
-        List<PayRequestTarget> payRequestTargetListByUser = payDao.findPayRequestTargetListByUser(userByUserId);
+        // TODO 2. spaceId에 해당하는 space find
+        Space spaceBySpaceId = spaceUtils.findSpaceBySpaceId(spaceId);
+        
+        // TODO 3. 유저가 요청받은 정산 중 진행 중인 정산 리스트 select
+        List<PayRequestTarget> payRequestTargetListByUser = payDao.findPayRequestTargetListByUser(userByUserId, spaceBySpaceId);
 
-        // TODO 3. return 타입 구성
+        // TODO 4. return 타입 구성
         // 3-1. 각 payRequestTarget 에 해당하는 정산 요청자, 정산 요청 금액 을 loop를 돌면서 데이터 수집
         List<PayReceiveInfoDto> payReceiveInfoDtoList = new ArrayList<>();
 

--- a/src/main/java/space/space_spring/service/PayService.java
+++ b/src/main/java/space/space_spring/service/PayService.java
@@ -38,7 +38,7 @@ public class PayService {
             int totalTargetNum = 0;
             int receiveTargetNum = 0;
 
-            List<PayRequestTarget> payRequestTargetList = payDao.findPayRequestTargetList(payRequest);
+            List<PayRequestTarget> payRequestTargetList = payDao.findPayRequestTargetListByPayRequest(payRequest);
             for (PayRequestTarget payRequestTarget : payRequestTargetList) {
                 if (payRequestTarget.isComplete()) {
                     // 해당 타겟이 돈을 낸 경우
@@ -57,7 +57,25 @@ public class PayService {
     }
 
     public List<PayReceiveInfoDto> getPayReceiveInfoForUser(Long userId, Long spaceId) {
+        // TODO 1. userId에 해당하는 유저 find
+        User userByUserId = userUtils.findUserByUserId(userId);
 
+        // TODO 2. 유저가 요청받은 정산 중 진행 중인 정산 리스트 select
+        List<PayRequestTarget> payRequestTargetListByUser = payDao.findPayRequestTargetListByUser(userByUserId);
 
+        // TODO 3. return 타입 구성
+        // 3-1. 각 payRequestTarget 에 해당하는 정산 요청자, 정산 요청 금액 을 loop를 돌면서 데이터 수집
+        List<PayReceiveInfoDto> payReceiveInfoDtoList = new ArrayList<>();
+
+        for (PayRequestTarget payRequestTarget : payRequestTargetListByUser) {
+            String payCreatorName = payRequestTarget.getPayRequest().getPayCreateUser().getUserName();          // 리펙토링 필요
+            int requestAmount = payRequestTarget.getRequestAmount();
+
+            PayReceiveInfoDto payReceiveInfoDto = new PayReceiveInfoDto(payCreatorName, requestAmount);
+
+            payReceiveInfoDtoList.add(payReceiveInfoDto);
+        }
+
+        return payReceiveInfoDtoList;
     }
 }

--- a/src/main/java/space/space_spring/service/PayService.java
+++ b/src/main/java/space/space_spring/service/PayService.java
@@ -15,7 +15,11 @@ public class PayService {
     private final PayDao payDao;
 
     public List<PayRequestInfoDto> getPayRequestInfoForUser(Long userId, Long spaceId) {
-        // TODO 1. 유저가 생성한
+        // TODO 1. userId에 해당하는 user find
+
+
+        // TODO 1. 유저가 요청한 정산 중 진행 중인 정산 리스트 select
+        payDao.findPayRequestListByUser()
 
     }
 

--- a/src/main/java/space/space_spring/service/PayService.java
+++ b/src/main/java/space/space_spring/service/PayService.java
@@ -15,7 +15,8 @@ public class PayService {
     private final PayDao payDao;
 
     public List<PayRequestInfoDto> getPayRequestInfoForUser(Long userId, Long spaceId) {
-        
+        // TODO 1. 유저가 생성한
+
     }
 
     public List<PayReceiveInfoDto> getPayReceiveInfoForUser(Long userId, Long spaceId) {

--- a/src/main/java/space/space_spring/service/PayService.java
+++ b/src/main/java/space/space_spring/service/PayService.java
@@ -3,10 +3,21 @@ package space.space_spring.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import space.space_spring.dao.PayDao;
+import space.space_spring.dto.pay.PayReceiveInfoDto;
+import space.space_spring.dto.pay.PayRequestInfoDto;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PayService {
 
     private final PayDao payDao;
+
+    public List<PayRequestInfoDto> getPayRequestInfoForUser(Long userId, Long spaceId) {
+        
+    }
+
+    public List<PayReceiveInfoDto> getPayReceiveInfoForUser(Long userId, Long spaceId) {
+    }
 }

--- a/src/main/java/space/space_spring/service/PayService.java
+++ b/src/main/java/space/space_spring/service/PayService.java
@@ -5,7 +5,12 @@ import org.springframework.stereotype.Service;
 import space.space_spring.dao.PayDao;
 import space.space_spring.dto.pay.PayReceiveInfoDto;
 import space.space_spring.dto.pay.PayRequestInfoDto;
+import space.space_spring.entity.PayRequest;
+import space.space_spring.entity.PayRequestTarget;
+import space.space_spring.entity.User;
+import space.space_spring.util.user.UserUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -13,16 +18,46 @@ import java.util.List;
 public class PayService {
 
     private final PayDao payDao;
+    private final UserUtils userUtils;
 
     public List<PayRequestInfoDto> getPayRequestInfoForUser(Long userId, Long spaceId) {
         // TODO 1. userId에 해당하는 user find
+        User userByUserId = userUtils.findUserByUserId(userId);
 
+        // TODO 2. 유저가 요청한 정산 중 진행 중인 정산 리스트 select
+        List<PayRequest> payRequestListByUser = payDao.findPayRequestListByUser(userByUserId);
 
-        // TODO 1. 유저가 요청한 정산 중 진행 중인 정산 리스트 select
-        payDao.findPayRequestListByUser()
+        // TODO 3. return 타입 구성
+        // 3-1. 각 payRequest 에 해당하는 모든 payRequestTarget 을 loop로 돌면서 데이터 수집
+        List<PayRequestInfoDto> payRequestInfoDtoList = new ArrayList<>();
 
+        for (PayRequest payRequest : payRequestListByUser) {
+            // 하나의 정산 요청에 대하여 ,,,
+            int totalAmount = payRequest.getTotalAmount();
+            int receiveAmount = 0;
+            int totalTargetNum = 0;
+            int receiveTargetNum = 0;
+
+            List<PayRequestTarget> payRequestTargetList = payDao.findPayRequestTargetList(payRequest);
+            for (PayRequestTarget payRequestTarget : payRequestTargetList) {
+                if (payRequestTarget.isComplete()) {
+                    // 해당 타겟이 돈을 낸 경우
+                    receiveAmount += payRequestTarget.getRequestAmount();
+                    receiveTargetNum++;
+                }
+
+                totalTargetNum++;
+            }
+
+            PayRequestInfoDto payRequestInfoDto = new PayRequestInfoDto(totalAmount, receiveAmount, totalTargetNum, receiveTargetNum);
+            payRequestInfoDtoList.add(payRequestInfoDto);
+        }
+
+        return payRequestInfoDtoList;
     }
 
     public List<PayReceiveInfoDto> getPayReceiveInfoForUser(Long userId, Long spaceId) {
+
+
     }
 }

--- a/src/main/java/space/space_spring/service/PayService.java
+++ b/src/main/java/space/space_spring/service/PayService.java
@@ -1,0 +1,12 @@
+package space.space_spring.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import space.space_spring.dao.PayDao;
+
+@Service
+@RequiredArgsConstructor
+public class PayService {
+
+    private final PayDao payDao;
+}

--- a/src/main/java/space/space_spring/service/UserService.java
+++ b/src/main/java/space/space_spring/service/UserService.java
@@ -11,6 +11,7 @@ import space.space_spring.dao.UserDao;
 import space.space_spring.entity.User;
 import space.space_spring.exception.UserException;
 import space.space_spring.response.BaseResponse;
+import space.space_spring.util.user.UserUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,7 @@ public class UserService {
     private final UserDao userDao;
     private final JwtLoginProvider jwtLoginProvider;
     private final UserSpaceDao userSpaceDao;
+    private final UserUtils userUtils;
 
     @Transactional
     public PostUserSignupResponse signup(PostUserSignupRequest postUserSignupRequest) {
@@ -52,7 +54,7 @@ public class UserService {
     @Transactional
     public String login(PostUserLoginRequest postUserLoginRequest) {
         // TODO 1. 이메일 존재 여부 확인(아이디 존재 여부 확인)
-        User userByEmail = findUserByEmail(postUserLoginRequest.getEmail());
+        User userByEmail = userUtils.findUserByEmail(postUserLoginRequest.getEmail());
         log.info("userByEmail.getUserId: {}", userByEmail.getUserId());
 
         // TODO 2. 비밀번호 일치 여부 확인
@@ -67,14 +69,6 @@ public class UserService {
         return jwtLogin;
     }
 
-    private User findUserByEmail(String email) {
-        User findUser = userDao.getUserByEmail(email);
-        if (findUser == null) {
-            throw new UserException(EMAIL_NOT_FOUND);
-        }
-        return findUser;
-    }
-
     private void validatePassword(User userByEmail, String password) {
         if (!userByEmail.passwordMatch(password)) {
             throw new UserException(PASSWORD_NO_MATCH);
@@ -84,7 +78,7 @@ public class UserService {
     @Transactional
     public GetSpaceInfoForUserResponse getSpaceListForUser(Long userId, int size, Long lastUserSpaceId) {
         // TODO 1. userId로 User find
-        User userByUserId = findUserByUserId(userId);
+        User userByUserId = userUtils.findUserByUserId(userId);
 
         // TODO 2. user가 속한 스페이스가 없는 경우 -> 예외처리 ??
         // (현재 lastUserSpaceId가 -1 & 스페이스 info list는 빈 껍데기로 response가 전달됨)
@@ -103,14 +97,6 @@ public class UserService {
     private void validateSpaceListForUser(User userByUserId) {
         // 프론트 개발자 분들과 상의해서 결정해야할 거 같음
 
-    }
-
-    private User findUserByUserId(Long userId) {
-        User userByUserId = userDao.findUserByUserId(userId);
-        if (userByUserId == null) {
-            throw new UserException(USER_NOT_FOUND);
-        }
-        return userByUserId;
     }
 
 }

--- a/src/main/java/space/space_spring/util/space/SpaceUtils.java
+++ b/src/main/java/space/space_spring/util/space/SpaceUtils.java
@@ -1,0 +1,27 @@
+package space.space_spring.util.space;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import space.space_spring.dao.SpaceDao;
+import space.space_spring.entity.Space;
+import space.space_spring.exception.SpaceException;
+
+import static space.space_spring.response.status.BaseExceptionResponseStatus.SPACE_NOT_FOUND;
+
+@Component
+@RequiredArgsConstructor
+public class SpaceUtils {
+
+    private final SpaceDao spaceDao;
+
+    @Transactional
+    public Space findSpaceBySpaceId(Long spaceId) {
+        Space spaceBySpaceId = spaceDao.findSpaceBySpaceId(spaceId);
+        if (spaceBySpaceId == null) {
+            throw new SpaceException(SPACE_NOT_FOUND);
+        }
+        return spaceBySpaceId;
+    }
+
+}

--- a/src/main/java/space/space_spring/util/user/UserUtils.java
+++ b/src/main/java/space/space_spring/util/user/UserUtils.java
@@ -1,0 +1,36 @@
+package space.space_spring.util.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import space.space_spring.dao.UserDao;
+import space.space_spring.entity.User;
+import space.space_spring.exception.UserException;
+
+import static space.space_spring.response.status.BaseExceptionResponseStatus.EMAIL_NOT_FOUND;
+import static space.space_spring.response.status.BaseExceptionResponseStatus.USER_NOT_FOUND;
+
+@Component
+@RequiredArgsConstructor
+public class UserUtils {
+
+    private final UserDao userDao;
+
+    @Transactional
+    public User findUserByEmail(String email) {
+        User findUser = userDao.getUserByEmail(email);
+        if (findUser == null) {
+            throw new UserException(EMAIL_NOT_FOUND);
+        }
+        return findUser;
+    }
+
+    @Transactional
+    public User findUserByUserId(Long userId) {
+        User userByUserId = userDao.findUserByUserId(userId);
+        if (userByUserId == null) {
+            throw new UserException(USER_NOT_FOUND);
+        }
+        return userByUserId;
+    }
+}

--- a/src/test/java/space/space_spring/service/PayServiceTest.java
+++ b/src/test/java/space/space_spring/service/PayServiceTest.java
@@ -8,10 +8,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import space.space_spring.dao.PayDao;
+import space.space_spring.dto.pay.PayReceiveInfoDto;
+import space.space_spring.dto.pay.PayRequestInfoDto;
 import space.space_spring.entity.PayRequest;
 import space.space_spring.entity.PayRequestTarget;
 import space.space_spring.entity.Space;
 import space.space_spring.entity.User;
+import space.space_spring.util.space.SpaceUtils;
 import space.space_spring.util.user.UserUtils;
 
 import java.util.List;
@@ -20,55 +23,91 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.*;
 
-//@ExtendWith(MockitoExtension.class)
-//class PayServiceTest {
-//
-//    @InjectMocks
-//    private PayService payService;
-//
-//    @Mock
-//    private PayDao payDao;
-//
-//    @Mock
-//    private UserUtils userUtils;
-//
-//    private User user1;
-//    private User user2;
-//    private Space testSpace;
-//    private PayRequest testPayRequest;
-//    private PayRequestTarget testPayRequestTarget;
-//
-//    @BeforeEach
-//    public void 테스트_셋업() {
-//        user1 = new User();
-//        user1.saveUser("test1@test.com", "abcDEF123!@", "user1");
-//
-//        user2 = new User();
-//        user2.saveUser("test2@test.com", "abcDEF123!@", "user2");
-//
-//        testSpace = new Space();
-//        testSpace.saveSpace("testSpace", "test_profile_img_url");
-//
-//        // user2가 요청한 정산 -> user1 에게
-//        testPayRequest = new PayRequest();
-//        testPayRequest.savePayRequest(user2, testSpace, 30000, "우리은행", "111-111-111", false);
-//
-//        testPayRequestTarget = new PayRequestTarget();
-//        testPayRequestTarget.savePayRequestTarget(testPayRequest, user1.getUserId(), 10000, false);
-//    }
-//
-//    @Test
-//    @DisplayName("getPayRequestInfoForUser_메서드_테스트")
-//    void 유저가_요청한_정산_중_진행중인_정산리스트_찾는_메서드_테스트() throws Exception {
-//        //given
-//
-//        //when
-//        List<PayRequest> payRequestListByUser = payDao.findPayRequestListByUser(user2, testSpace);
-//
-//        //then
-//        assertThat(payRequestListByUser).isNotEmpty();
-//        assertThat(payRequestListByUser.size()).isEqualTo(1);
-//        assertThat(payRequestListByUser.get(0)).isEqualTo(testPayRequest);
-//    }
-//
-//}
+@ExtendWith(MockitoExtension.class)
+class PayServiceTest {
+
+    @InjectMocks
+    private PayService payService;
+
+    @Mock
+    private PayDao payDao;
+
+    @Mock
+    private UserUtils userUtils;
+
+    @Mock
+    private SpaceUtils spaceUtils;
+
+    private User user1;
+    private User user2;
+    private Space testSpace;
+    private PayRequest testPayRequest;
+    private PayRequestTarget testPayRequestTarget;
+
+    @BeforeEach
+    public void 테스트_셋업() {
+        /**
+         * user2이 같은 스페이스에 속한 user1에게 정산을 요청한 상황 가정
+         */
+        user1 = new User();
+        user1.saveUser("test1@test.com", "abcDEF123!@", "user1");
+
+        user2 = new User();
+        user2.saveUser("test2@test.com", "abcDEF123!@", "user2");
+
+        testSpace = new Space();
+        testSpace.saveSpace("testSpace", "test_profile_img_url");
+
+        testPayRequest = new PayRequest();
+        testPayRequest.savePayRequest(user2, testSpace, 30000, "우리은행", "111-111-111", false);
+
+        testPayRequestTarget = new PayRequestTarget();
+        testPayRequestTarget.savePayRequestTarget(testPayRequest, user1.getUserId(), 10000, false);
+    }
+
+    @Test
+    @DisplayName("getPayRequestInfoForUser_메서드_테스트")
+    void 유저가_요청한_정산_중_진행중인_정산리스트_찾는_메서드_테스트() throws Exception {
+        //given
+        when(userUtils.findUserByUserId(user2.getUserId())).thenReturn(user2);
+        when(spaceUtils.findSpaceBySpaceId(testSpace.getSpaceId())).thenReturn(testSpace);
+        when(payDao.findPayRequestListByUser(user2, testSpace)).thenReturn(List.of(testPayRequest));
+        when(payDao.findPayRequestTargetListByPayRequest(testPayRequest)).thenReturn(List.of(testPayRequestTarget));
+
+        //when
+        List<PayRequestInfoDto> payRequestInfoForUser = payService.getPayRequestInfoForUser(user2.getUserId(), testSpace.getSpaceId());
+
+        //then
+        assertThat(payRequestInfoForUser.size()).isEqualTo(1);
+
+        for (PayRequestInfoDto payRequestInfoDto : payRequestInfoForUser) {
+            assertThat(payRequestInfoDto.getTotalAmount()).isEqualTo(30000);
+            assertThat(payRequestInfoDto.getReceiveAmount()).isEqualTo(0);
+            assertThat(payRequestInfoDto.getTotalTargetNum()).isEqualTo(1);
+            assertThat(payRequestInfoDto.getReceiveTargetNum()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    @DisplayName("Test name")
+    void 유저가_요청받은_정산_중_진행중인_정산리스트_찾는_메서드_테스트() throws Exception {
+        //given
+        when(userUtils.findUserByUserId(user1.getUserId())).thenReturn(user1);
+        when(spaceUtils.findSpaceBySpaceId(testSpace.getSpaceId())).thenReturn(testSpace);
+        when(payDao.findPayRequestTargetListByUser(user1, testSpace)).thenReturn(List.of(testPayRequestTarget));
+
+        //when
+        List<PayReceiveInfoDto> payReceiveInfoForUser = payService.getPayReceiveInfoForUser(user1.getUserId(), testSpace.getSpaceId());
+
+        //then
+        assertThat(payReceiveInfoForUser.size()).isEqualTo(1);
+        for (PayReceiveInfoDto payReceiveInfoDto : payReceiveInfoForUser) {
+            assertThat(payReceiveInfoDto.getPayCreatorName()).isEqualTo(user2.getUserName());
+            assertThat(payReceiveInfoDto.getRequestAmount()).isEqualTo(10000);
+        }
+    }
+
+
+
+
+}

--- a/src/test/java/space/space_spring/service/PayServiceTest.java
+++ b/src/test/java/space/space_spring/service/PayServiceTest.java
@@ -14,48 +14,61 @@ import space.space_spring.entity.Space;
 import space.space_spring.entity.User;
 import space.space_spring.util.user.UserUtils;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.*;
 
-@ExtendWith(MockitoExtension.class)
-class PayServiceTest {
-
-    @InjectMocks
-    private PayService payService;
-
-    @Mock
-    private PayDao payDao;
-
-    @Mock
-    private UserUtils userUtils;
-
-    @BeforeEach
-    public void 테스트_셋업() {
-        User user1 = new User();
-        user1.saveUser("test1@test.com", "abcDEF123!@", "user1");
-
-        User user2 = new User();
-        user2.saveUser("test2@test.com", "abcDEF123!@", "user2");
-
-        Space testSpace = new Space();
-        testSpace.saveSpace("testSpace", "test_profile_img_url");
-
-        // user2가 요청한 정산 -> user1 에게
-        PayRequest testPayRequest = new PayRequest();
-        testPayRequest.savePayRequest(user2, testSpace, 30000, "우리은행", "111-111-111", false);
-
-        PayRequestTarget testPayRequestTarget = new PayRequestTarget();
-        testPayRequestTarget.savePayRequestTarget(testPayRequest, user1.getUserId(), 10000, false);
-    }
-
-    @Test
-    @DisplayName("getPayRequestInfoForUser_메서드_테스트")
-    void getPayRequestInfoForUser_메서드_테스트() throws Exception {
-        //given
-        
-
-        //when
-        
-        //then
-    }
-    
-}
+//@ExtendWith(MockitoExtension.class)
+//class PayServiceTest {
+//
+//    @InjectMocks
+//    private PayService payService;
+//
+//    @Mock
+//    private PayDao payDao;
+//
+//    @Mock
+//    private UserUtils userUtils;
+//
+//    private User user1;
+//    private User user2;
+//    private Space testSpace;
+//    private PayRequest testPayRequest;
+//    private PayRequestTarget testPayRequestTarget;
+//
+//    @BeforeEach
+//    public void 테스트_셋업() {
+//        user1 = new User();
+//        user1.saveUser("test1@test.com", "abcDEF123!@", "user1");
+//
+//        user2 = new User();
+//        user2.saveUser("test2@test.com", "abcDEF123!@", "user2");
+//
+//        testSpace = new Space();
+//        testSpace.saveSpace("testSpace", "test_profile_img_url");
+//
+//        // user2가 요청한 정산 -> user1 에게
+//        testPayRequest = new PayRequest();
+//        testPayRequest.savePayRequest(user2, testSpace, 30000, "우리은행", "111-111-111", false);
+//
+//        testPayRequestTarget = new PayRequestTarget();
+//        testPayRequestTarget.savePayRequestTarget(testPayRequest, user1.getUserId(), 10000, false);
+//    }
+//
+//    @Test
+//    @DisplayName("getPayRequestInfoForUser_메서드_테스트")
+//    void 유저가_요청한_정산_중_진행중인_정산리스트_찾는_메서드_테스트() throws Exception {
+//        //given
+//
+//        //when
+//        List<PayRequest> payRequestListByUser = payDao.findPayRequestListByUser(user2, testSpace);
+//
+//        //then
+//        assertThat(payRequestListByUser).isNotEmpty();
+//        assertThat(payRequestListByUser.size()).isEqualTo(1);
+//        assertThat(payRequestListByUser.get(0)).isEqualTo(testPayRequest);
+//    }
+//
+//}

--- a/src/test/java/space/space_spring/service/PayServiceTest.java
+++ b/src/test/java/space/space_spring/service/PayServiceTest.java
@@ -1,0 +1,61 @@
+package space.space_spring.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import space.space_spring.dao.PayDao;
+import space.space_spring.entity.PayRequest;
+import space.space_spring.entity.PayRequestTarget;
+import space.space_spring.entity.Space;
+import space.space_spring.entity.User;
+import space.space_spring.util.user.UserUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class PayServiceTest {
+
+    @InjectMocks
+    private PayService payService;
+
+    @Mock
+    private PayDao payDao;
+
+    @Mock
+    private UserUtils userUtils;
+
+    @BeforeEach
+    public void 테스트_셋업() {
+        User user1 = new User();
+        user1.saveUser("test1@test.com", "abcDEF123!@", "user1");
+
+        User user2 = new User();
+        user2.saveUser("test2@test.com", "abcDEF123!@", "user2");
+
+        Space testSpace = new Space();
+        testSpace.saveSpace("testSpace", "test_profile_img_url");
+
+        // user2가 요청한 정산 -> user1 에게
+        PayRequest testPayRequest = new PayRequest();
+        testPayRequest.savePayRequest(user2, testSpace, 30000, "우리은행", "111-111-111", false);
+
+        PayRequestTarget testPayRequestTarget = new PayRequestTarget();
+        testPayRequestTarget.savePayRequestTarget(testPayRequest, user1.getUserId(), 10000, false);
+    }
+
+    @Test
+    @DisplayName("getPayRequestInfoForUser_메서드_테스트")
+    void getPayRequestInfoForUser_메서드_테스트() throws Exception {
+        //given
+        
+
+        //when
+        
+        //then
+    }
+    
+}


### PR DESCRIPTION
## 📝 요약
메뉴의 정산 홈으로 들어왔을때 필요한 데이터들을 프론트단으로 보내주는 api 입니다
유저가 해당 스페이스 내에서 요청한 정산 중, 현재 진행중인 정산 리스트 정보와
유저가 해당 스페이스 내에서 요청받은 정산 중, 현재 진행중인 정산 리스트 정보를 response 값으로 보내줍니다.
서비스단의 코드를 junit5와 Mockito 를 이용하여 테스트하였고, 테스트가 잘 작동되는것을 확인했습니다.
다만, 레포지토리단의 코드는 아직 테스트를 해보지 않았습니다.
추후에 정산을 직접 생성하는 api를 개발한 후, 실제 db에 데이터가 잘 들어가는지 확인하거나, 레포지토리단의 테스트코드도 추가해보겠습니다.

이슈 번호 : #37 

## 🔖 변경 사항
- 정산 관련 컨트롤러, 서비스, 레포지토리 클래스 생성 (계층 구조 생성)
- request로 넘어오는 spaceId에 해당하는 스페이스 엔티티를 찾기위해 SpaceUtils 클래스 정의
- jwt로 확인할 수 있는 유저가 request로 넘어오는 스페이스에 속하는 유저인지를 확인하기 위해 UserSpaceUtils의 검증 로직을 컨트롤러에서 수행 
  -> 이 검증 로직은 유저가 스페이스 내에서 수행하는 작업을 위한 모든 api 에서 필요할 것 같습니다.
- 서비스 단 코드를 테스트하기 위한 PayServiceTest 클래스 생성

## ✅ 리뷰 요구사항
현재 정산 관련 서비스 단의 코드가 조금 지저분합니다.
추후에 리펙토링을 할 계획인데, 코드 리펙토링에 대한 의견있으면 리뷰 남겨주시면 감사하겠습니다

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
