### PR TITLE
feat/#29: 채팅방 api 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'			// webSocket 추가
 
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	//JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -57,3 +57,7 @@ dependencies {
 test {
 	useJUnitPlatform()
 }
+
+clean {
+	delete file('src/main/generated')
+}

--- a/src/main/java/space/space_spring/config/QueryDslConfig.java
+++ b/src/main/java/space/space_spring/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package space.space_spring.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @Autowired
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/space/space_spring/config/WebConfig.java
+++ b/src/main/java/space/space_spring/config/WebConfig.java
@@ -20,7 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final JwtLoginAuthHandlerArgumentResolver jwtLoginAuthHandlerArgumentResolver;
 
-    private static final String DEVELOP_FRONT_ADDRESS = "http://localhost:3000";
+    private static final String DEVELOP_FRONT_ADDRESS = "http://localhost:5173";
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
@@ -41,7 +41,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins(DEVELOP_FRONT_ADDRESS)
+                .allowedOrigins(String.valueOf(List.of(DEVELOP_FRONT_ADDRESS, "http://localhost:3000")))
                 .allowedMethods("GET", "POST", "PUT", "DELETE")
                 .exposedHeaders("location")
                 .allowedHeaders("*")

--- a/src/main/java/space/space_spring/controller/ChatRoomController.java
+++ b/src/main/java/space/space_spring/controller/ChatRoomController.java
@@ -18,16 +18,16 @@ import static space.space_spring.util.bindingResult.BindingResultUtils.getErrorM
 
 @RestController
 @RequiredArgsConstructor
-//@RequestMapping("/chatroom")
+@RequestMapping("/space/{spaceId}/chat")
 public class ChatRoomController {
     private final ChatRoomService chatRoomService;
 
-    @GetMapping("/space/{spaceId}/chat/chatroom")
+    @GetMapping("/chatroom")
     public BaseResponse<ReadChatRoomResponse> readChatRooms(@JwtLoginAuth Long userId, @PathVariable Long spaceId) {
         return new BaseResponse<>(chatRoomService.readChatRooms(userId, spaceId));
     }
 
-    @PostMapping("/space/{spaceId}/chat/chatroom")
+    @PostMapping("/chatroom")
     public BaseResponse<CreateChatRoomResponse> createChatRoom(
             @JwtLoginAuth Long userId,
             @PathVariable Long spaceId,

--- a/src/main/java/space/space_spring/controller/ChatRoomController.java
+++ b/src/main/java/space/space_spring/controller/ChatRoomController.java
@@ -1,0 +1,22 @@
+package space.space_spring.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import space.space_spring.argument_resolver.jwtLogin.JwtLoginAuth;
+import space.space_spring.dto.chat.ReadChatRoomResponse;
+import space.space_spring.response.BaseResponse;
+import space.space_spring.service.ChatRoomService;
+
+@RestController
+@RequiredArgsConstructor
+//@RequestMapping("/chatroom")
+public class ChatRoomController {
+    private final ChatRoomService chatRoomService;
+
+    @GetMapping("/space/{spaceId}/chatroom")
+    public BaseResponse<ReadChatRoomResponse> readChatRooms(@JwtLoginAuth Long userId, @PathVariable Long spaceId) {
+        return new BaseResponse<>(chatRoomService.readChatRooms(userId, spaceId));
+    }
+}

--- a/src/main/java/space/space_spring/controller/ChatRoomController.java
+++ b/src/main/java/space/space_spring/controller/ChatRoomController.java
@@ -41,7 +41,7 @@ public class ChatRoomController {
             BindingResult bindingResult) throws IOException {
 
         if (!userSpaceUtils.isUserManager(userId, spaceId)) {
-            throw new ChatException(UNAUTHORIZED_USER, getErrorMessage(bindingResult));
+            throw new ChatException(UNAUTHORIZED_USER);
         }
 
         if (bindingResult.hasErrors()) {

--- a/src/main/java/space/space_spring/controller/ChatRoomController.java
+++ b/src/main/java/space/space_spring/controller/ChatRoomController.java
@@ -12,10 +12,12 @@ import space.space_spring.exception.ChatException;
 import space.space_spring.response.BaseResponse;
 import space.space_spring.service.ChatRoomService;
 import space.space_spring.service.S3Uploader;
+import space.space_spring.util.userSpace.UserSpaceUtils;
 
 import java.io.IOException;
 
 import static space.space_spring.response.status.BaseExceptionResponseStatus.INVALID_CHATROOM_CREATE;
+import static space.space_spring.response.status.BaseExceptionResponseStatus.UNAUTHORIZED_USER;
 import static space.space_spring.util.bindingResult.BindingResultUtils.getErrorMessage;
 
 @RestController
@@ -24,6 +26,7 @@ import static space.space_spring.util.bindingResult.BindingResultUtils.getErrorM
 public class ChatRoomController {
     private final ChatRoomService chatRoomService;
     private final S3Uploader s3Uploader;
+    private final UserSpaceUtils userSpaceUtils;
 
     @GetMapping("/chatroom")
     public BaseResponse<ReadChatRoomResponse> readChatRooms(@JwtLoginAuth Long userId, @PathVariable Long spaceId) {
@@ -36,6 +39,10 @@ public class ChatRoomController {
             @PathVariable Long spaceId,
             @Validated @ModelAttribute CreateChatRoomRequest createChatRoomRequest,
             BindingResult bindingResult) throws IOException {
+
+        if (!userSpaceUtils.isUserManager(userId, spaceId)) {
+            throw new ChatException(UNAUTHORIZED_USER, getErrorMessage(bindingResult));
+        }
 
         if (bindingResult.hasErrors()) {
             throw new ChatException(INVALID_CHATROOM_CREATE, getErrorMessage(bindingResult));

--- a/src/main/java/space/space_spring/controller/ChatRoomController.java
+++ b/src/main/java/space/space_spring/controller/ChatRoomController.java
@@ -1,13 +1,20 @@
 package space.space_spring.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 import space.space_spring.argument_resolver.jwtLogin.JwtLoginAuth;
+import space.space_spring.dto.chat.CreateChatRoomRequest;
+import space.space_spring.dto.chat.CreateChatRoomResponse;
 import space.space_spring.dto.chat.ReadChatRoomResponse;
+import space.space_spring.exception.ChatException;
+import space.space_spring.exception.SpaceException;
 import space.space_spring.response.BaseResponse;
 import space.space_spring.service.ChatRoomService;
+
+import static space.space_spring.response.status.BaseExceptionResponseStatus.INVALID_CHATROOM_CREATE;
+import static space.space_spring.util.bindingResult.BindingResultUtils.getErrorMessage;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,8 +22,22 @@ import space.space_spring.service.ChatRoomService;
 public class ChatRoomController {
     private final ChatRoomService chatRoomService;
 
-    @GetMapping("/space/{spaceId}/chatroom")
+    @GetMapping("/space/{spaceId}/chat/chatroom")
     public BaseResponse<ReadChatRoomResponse> readChatRooms(@JwtLoginAuth Long userId, @PathVariable Long spaceId) {
         return new BaseResponse<>(chatRoomService.readChatRooms(userId, spaceId));
+    }
+
+    @PostMapping("/space/{spaceId}/chat/chatroom")
+    public BaseResponse<CreateChatRoomResponse> createChatRoom(
+            @JwtLoginAuth Long userId,
+            @PathVariable Long spaceId,
+            @Validated @RequestBody CreateChatRoomRequest createChatRoomRequest,
+            BindingResult bindingResult) {
+
+        if (bindingResult.hasErrors()) {
+            throw new ChatException(INVALID_CHATROOM_CREATE, getErrorMessage(bindingResult));
+        }
+
+        return new BaseResponse<>(chatRoomService.createChatRoom(userId, spaceId, createChatRoomRequest));
     }
 }

--- a/src/main/java/space/space_spring/dao/chat/ChatRoomDao.java
+++ b/src/main/java/space/space_spring/dao/chat/ChatRoomDao.java
@@ -1,0 +1,10 @@
+package space.space_spring.dao.chat;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import space.space_spring.dao.chat.custom.ChatRoomDaoCustom;
+import space.space_spring.entity.ChatRoom;
+
+@Repository
+public interface ChatRoomDao extends JpaRepository<ChatRoom, Long>, ChatRoomDaoCustom {
+}

--- a/src/main/java/space/space_spring/dao/chat/UserChatRoomDao.java
+++ b/src/main/java/space/space_spring/dao/chat/UserChatRoomDao.java
@@ -1,0 +1,8 @@
+package space.space_spring.dao.chat;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import space.space_spring.entity.UserChatRoom;
+
+
+public interface UserChatRoomDao extends JpaRepository<UserChatRoom, Long> {
+}

--- a/src/main/java/space/space_spring/dao/chat/custom/ChatRoomDaoCustom.java
+++ b/src/main/java/space/space_spring/dao/chat/custom/ChatRoomDaoCustom.java
@@ -1,0 +1,11 @@
+package space.space_spring.dao.chat.custom;
+
+import space.space_spring.entity.ChatRoom;
+import space.space_spring.entity.Space;
+import space.space_spring.entity.User;
+
+import java.util.List;
+
+public interface ChatRoomDaoCustom {
+    List<ChatRoom> findByUserAndSpace(User user, Space space);
+}

--- a/src/main/java/space/space_spring/dao/chat/custom/ChatRoomDaoImpl.java
+++ b/src/main/java/space/space_spring/dao/chat/custom/ChatRoomDaoImpl.java
@@ -1,0 +1,30 @@
+package space.space_spring.dao.chat.custom;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import space.space_spring.entity.ChatRoom;
+import space.space_spring.entity.Space;
+import space.space_spring.entity.User;
+
+import java.util.List;
+
+import static space.space_spring.entity.QChatRoom.chatRoom;
+import static space.space_spring.entity.QUser.user;
+import static space.space_spring.entity.QUserChatRoom.userChatRoom;
+
+@RequiredArgsConstructor
+public class ChatRoomDaoImpl implements ChatRoomDaoCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<ChatRoom> findByUserAndSpace(User who, Space where) {
+        return jpaQueryFactory
+                .selectFrom(chatRoom)
+                .join(chatRoom, userChatRoom.chatRoom)
+                .where(user.eq(who)
+                        .and(chatRoom.space.eq(where)))
+                .orderBy(chatRoom.lastModifiedAt.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/space/space_spring/dao/chat/custom/ChatRoomDaoImpl.java
+++ b/src/main/java/space/space_spring/dao/chat/custom/ChatRoomDaoImpl.java
@@ -9,7 +9,6 @@ import space.space_spring.entity.User;
 import java.util.List;
 
 import static space.space_spring.entity.QChatRoom.chatRoom;
-import static space.space_spring.entity.QUser.user;
 import static space.space_spring.entity.QUserChatRoom.userChatRoom;
 
 @RequiredArgsConstructor
@@ -21,8 +20,8 @@ public class ChatRoomDaoImpl implements ChatRoomDaoCustom {
     public List<ChatRoom> findByUserAndSpace(User who, Space where) {
         return jpaQueryFactory
                 .selectFrom(chatRoom)
-                .join(chatRoom, userChatRoom.chatRoom)
-                .where(user.eq(who)
+                .join(userChatRoom).on(userChatRoom.chatRoom.eq(chatRoom))
+                .where(userChatRoom.user.eq(who)
                         .and(chatRoom.space.eq(where)))
                 .orderBy(chatRoom.lastModifiedAt.desc())
                 .fetch();

--- a/src/main/java/space/space_spring/dto/chat/ChatRoomResponse.java
+++ b/src/main/java/space/space_spring/dto/chat/ChatRoomResponse.java
@@ -3,6 +3,7 @@ package space.space_spring.dto.chat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import space.space_spring.entity.ChatRoom;
 
 @Builder
 @Getter
@@ -20,11 +21,11 @@ public class ChatRoomResponse {
 
     private int unreadMsgCount;
 
-    public static ChatRoomResponse of(Long id, String name, String imgUrl, String lastMsg, String lastTime, int unreadMsgCount) {
+    public static ChatRoomResponse of(ChatRoom chatRoom, String lastMsg, String lastTime, int unreadMsgCount) {
         return ChatRoomResponse.builder()
-                .id(id)
-                .name(name)
-                .imgUrl(imgUrl)
+                .id(chatRoom.getId())
+                .name(chatRoom.getName())
+                .imgUrl(chatRoom.getImg())
                 .lastMsg(lastMsg)
                 .lastTime(lastTime)
                 .unreadMsgCount(unreadMsgCount)

--- a/src/main/java/space/space_spring/dto/chat/ChatRoomResponse.java
+++ b/src/main/java/space/space_spring/dto/chat/ChatRoomResponse.java
@@ -1,0 +1,33 @@
+package space.space_spring.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class ChatRoomResponse {
+    private Long id;
+
+    private String name;
+
+    private String imgUrl;
+
+    private String lastMsg;
+
+    private String lastTime;
+
+    private int unreadMsgCount;
+
+    public static ChatRoomResponse of(Long id, String name, String imgUrl, String lastMsg, String lastTime, int unreadMsgCount) {
+        return ChatRoomResponse.builder()
+                .id(id)
+                .name(name)
+                .imgUrl(imgUrl)
+                .lastMsg(lastMsg)
+                .lastTime(lastTime)
+                .unreadMsgCount(unreadMsgCount)
+                .build();
+    }
+}

--- a/src/main/java/space/space_spring/dto/chat/CreateChatRoomRequest.java
+++ b/src/main/java/space/space_spring/dto/chat/CreateChatRoomRequest.java
@@ -1,0 +1,22 @@
+package space.space_spring.dto.chat;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CreateChatRoomRequest {
+
+    @Length(min = 2, max = 15, message = "채팅방 이름은 2자 이상, 15자 이내의 문자열이어야 합니다.")
+    @NotBlank(message = "채팅방 이름은 공백일 수 없습니다.")
+    private String name;
+
+    private String img;
+
+    // TODO: member 조회 API 개발 시 수정 예정
+    private List<String> memberList;
+}

--- a/src/main/java/space/space_spring/dto/chat/CreateChatRoomRequest.java
+++ b/src/main/java/space/space_spring/dto/chat/CreateChatRoomRequest.java
@@ -3,11 +3,14 @@ package space.space_spring.dto.chat;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class CreateChatRoomRequest {
 
@@ -15,7 +18,7 @@ public class CreateChatRoomRequest {
     @NotBlank(message = "채팅방 이름은 공백일 수 없습니다.")
     private String name;
 
-    private String img;
+    private MultipartFile img;
 
     // TODO: member 조회 API 개발 시 수정 예정
     private List<String> memberList;

--- a/src/main/java/space/space_spring/dto/chat/CreateChatRoomResponse.java
+++ b/src/main/java/space/space_spring/dto/chat/CreateChatRoomResponse.java
@@ -1,0 +1,18 @@
+package space.space_spring.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CreateChatRoomResponse {
+    private Long id;
+
+    public static CreateChatRoomResponse of(Long id) {
+        return CreateChatRoomResponse.builder()
+                .id(id)
+                .build();
+    }
+}

--- a/src/main/java/space/space_spring/dto/chat/ReadChatRoomResponse.java
+++ b/src/main/java/space/space_spring/dto/chat/ReadChatRoomResponse.java
@@ -1,0 +1,20 @@
+package space.space_spring.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ReadChatRoomResponse {
+    private List<ChatRoomResponse> chatRoomList;
+
+    public static ReadChatRoomResponse of(List<ChatRoomResponse> chatRooms) {
+        return ReadChatRoomResponse.builder()
+                .chatRoomList(chatRooms)
+                .build();
+    }
+}

--- a/src/main/java/space/space_spring/entity/ChatRoom.java
+++ b/src/main/java/space/space_spring/entity/ChatRoom.java
@@ -37,7 +37,7 @@ public class ChatRoom extends BaseEntity{
     @Column(name = "last_msg_id")
     private int lastMsgId;
 
-    // 양방향 매핑
-    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
-    private List<UserChatRoom> userChatRooms;
+//    // 양방향 매핑
+//    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
+//    private List<UserChatRoom> userChatRooms;
 }

--- a/src/main/java/space/space_spring/entity/ChatRoom.java
+++ b/src/main/java/space/space_spring/entity/ChatRoom.java
@@ -44,11 +44,11 @@ public class ChatRoom extends BaseEntity{
     @Column(name = "last_msg_id")
     private int lastMsgId;
 
-    public static ChatRoom of(Space space, CreateChatRoomRequest createChatRoomRequest) {
+    public static ChatRoom of(Space space, CreateChatRoomRequest createChatRoomRequest, String chatRoomImgUrl) {
         return ChatRoom.builder()
                 .space(space)
                 .name(createChatRoomRequest.getName())
-                .img(createChatRoomRequest.getImg())
+                .img(chatRoomImgUrl)
                 // TODO: 메시지 관련 처리 예정
                 .lastMsgId(0)
                 .build();

--- a/src/main/java/space/space_spring/entity/ChatRoom.java
+++ b/src/main/java/space/space_spring/entity/ChatRoom.java
@@ -1,0 +1,43 @@
+package space.space_spring.entity;
+
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Comment("채팅방")
+@Table(name = "Chat_Room")
+public class ChatRoom extends BaseEntity{
+
+    @Id
+    @GeneratedValue
+    @Column(name = "chat_room_id")
+    private Long id;
+
+    @Comment("채팅방이 속한 스페이스 ID")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "space_id")
+    private Space space;
+
+    @Comment("채팅방 이름")
+    @Column(name = "chat_room_name")
+    private String name;
+
+    @Comment("채팅방 이미지")
+    @Nullable
+    @Column(name = "chat_room_img")
+    private String img;
+
+    @Comment("마지막으로 전송된 메시지 ID")
+    @Nullable
+    @Column(name = "last_msg_id")
+    private int lastMsgId;
+
+    // 양방향 매핑
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
+    private List<UserChatRoom> userChatRooms;
+}

--- a/src/main/java/space/space_spring/entity/ChatRoom.java
+++ b/src/main/java/space/space_spring/entity/ChatRoom.java
@@ -2,13 +2,20 @@ package space.space_spring.entity;
 
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+import space.space_spring.dto.chat.CreateChatRoomRequest;
 
 import java.util.List;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Comment("채팅방")
 @Table(name = "Chat_Room")
 public class ChatRoom extends BaseEntity{
@@ -36,6 +43,16 @@ public class ChatRoom extends BaseEntity{
     @Nullable
     @Column(name = "last_msg_id")
     private int lastMsgId;
+
+    public static ChatRoom of(Space space, CreateChatRoomRequest createChatRoomRequest) {
+        return ChatRoom.builder()
+                .space(space)
+                .name(createChatRoomRequest.getName())
+                .img(createChatRoomRequest.getImg())
+                // TODO: 메시지 관련 처리 예정
+                .lastMsgId(0)
+                .build();
+    }
 
 //    // 양방향 매핑
 //    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)

--- a/src/main/java/space/space_spring/entity/UserChatRoom.java
+++ b/src/main/java/space/space_spring/entity/UserChatRoom.java
@@ -1,0 +1,47 @@
+package space.space_spring.entity;
+
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Comment("유저별 채팅방")
+@Table(name = "User_Chat_Room")
+public class UserChatRoom extends BaseEntity{
+
+    @Id
+    @GeneratedValue
+    @Column(name = "user_chat_id")
+    private Long id;
+
+    @Comment("채팅방 ID")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
+    @Comment("사용자 ID")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Comment("마지막으로 읽은 메시지 ID")
+    @Nullable
+    @Column(name = "last_read_msg_id")
+    private Long lastReadMsgId;
+
+    public UserChatRoom of(ChatRoom chatRoom, User user, Long lastReadMsgId) {
+        return UserChatRoom.builder()
+                .chatRoom(chatRoom)
+                .user(user)
+                .lastReadMsgId(lastReadMsgId)
+                .build();
+    }
+}

--- a/src/main/java/space/space_spring/entity/UserChatRoom.java
+++ b/src/main/java/space/space_spring/entity/UserChatRoom.java
@@ -37,7 +37,7 @@ public class UserChatRoom extends BaseEntity{
     @Column(name = "last_read_msg_id")
     private Long lastReadMsgId;
 
-    public UserChatRoom of(ChatRoom chatRoom, User user, Long lastReadMsgId) {
+    public static UserChatRoom of(ChatRoom chatRoom, User user, Long lastReadMsgId) {
         return UserChatRoom.builder()
                 .chatRoom(chatRoom)
                 .user(user)

--- a/src/main/java/space/space_spring/exception/ChatException.java
+++ b/src/main/java/space/space_spring/exception/ChatException.java
@@ -1,0 +1,20 @@
+package space.space_spring.exception;
+
+import lombok.Getter;
+import space.space_spring.response.status.ResponseStatus;
+
+@Getter
+public class ChatException extends RuntimeException{
+
+    private final ResponseStatus exceptionStatus;
+
+    public ChatException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public ChatException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
@@ -70,7 +70,13 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     D(7003, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 회원입니다."),
     E(7004, HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
     F(7005, HttpStatus.BAD_REQUEST.value(), "잘못된 회원 status 값입니다."),
-    G(7006, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 이메일입니다.");
+    G(7006, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 이메일입니다."),
+
+    /**
+     * 8000: Chat 오류
+     */
+    INVALID_CHATROOM_CREATE(8000, HttpStatus.BAD_REQUEST.value(), "채팅방 생성 요청에서 잘못된 값이 존재합니다.");
+
 
     private final int code;
     private final int status;

--- a/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
@@ -49,6 +49,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     EMAIL_NOT_FOUND(4006, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 이메일입니다."),
     INVALID_USER_LOGIN(4007, HttpStatus.BAD_REQUEST.value(), "로그인 요청에서 잘못된 값이 존재합니다."),
 
+
     /**
      * 6000: Space 오류
      */
@@ -65,7 +66,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
      * 7000: UserSpace 오류
      */
     USER_IS_NOT_IN_SPACE(7000, HttpStatus.BAD_REQUEST.value(), "해당 스페이스에 속하지 않는 유저입니다."),
-    B(7001, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 이메일입니다."),
+    UNAUTHORIZED_USER(7001, HttpStatus.UNAUTHORIZED.value(), "해당 스페이스에 관리자 권한이 없는 유저입니다."),
     C(7002, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 닉네임입니다."),
     D(7003, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 회원입니다."),
     E(7004, HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),

--- a/src/main/java/space/space_spring/service/ChatRoomService.java
+++ b/src/main/java/space/space_spring/service/ChatRoomService.java
@@ -38,10 +38,8 @@ public class ChatRoomService {
         // TODO 2: spaceId에 해당하는 space find
         Space spaceBySpaceId = spaceUtils.findSpaceBySpaceId(spaceId);
 
-        // TODO 3: 해당 user의 해당 space 내의 채팅방 리스트 select
+        // TODO 3: 해당 user의 해당 space 내의 채팅방 리스트 return
         List<ChatRoom> result = chatRoomDao.findByUserAndSpace(userByUserId, spaceBySpaceId);
-        log.info(result.toString());
-
         return ReadChatRoomResponse.of(result.stream()
                 .map(cr -> {
                     // TODO: chatting message 처리
@@ -55,7 +53,7 @@ public class ChatRoomService {
     }
 
     @Transactional
-    public CreateChatRoomResponse createChatRoom(Long userId, Long spaceId, CreateChatRoomRequest createChatRoomRequest) {
+    public CreateChatRoomResponse createChatRoom(Long userId, Long spaceId, CreateChatRoomRequest createChatRoomRequest, String chatRoomImgUrl) {
         // TODO 1: userId에 해당하는 user find
         User userByUserId = userUtils.findUserByUserId(userId);
 
@@ -63,13 +61,11 @@ public class ChatRoomService {
         Space spaceBySpaceId = spaceUtils.findSpaceBySpaceId(spaceId);
 
         // TODO 3: chatRoom 생성 및 저장
-        ChatRoom chatRoom = chatRoomDao.save(ChatRoom.of(spaceBySpaceId, createChatRoomRequest));
-        log.info(chatRoom.toString());
+        ChatRoom chatRoom = chatRoomDao.save(ChatRoom.of(spaceBySpaceId, createChatRoomRequest, chatRoomImgUrl));
 
         // TODO 4: user_chatRoom 매핑 정보 저장
         // TODO: 메시지 관련 처리 예정
         UserChatRoom userChatRoom = userChatRoomDao.save(UserChatRoom.of(chatRoom, userByUserId, null));
-        log.info(userChatRoom.toString());
 
         // TODO 5: chatroom id 반환
         return CreateChatRoomResponse.of(chatRoom.getId());

--- a/src/main/java/space/space_spring/service/ChatRoomService.java
+++ b/src/main/java/space/space_spring/service/ChatRoomService.java
@@ -1,5 +1,6 @@
 package space.space_spring.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -7,10 +8,13 @@ import space.space_spring.dao.UserDao;
 import space.space_spring.dao.chat.ChatRoomDao;
 import space.space_spring.dao.chat.UserChatRoomDao;
 import space.space_spring.dto.chat.ChatRoomResponse;
+import space.space_spring.dto.chat.CreateChatRoomRequest;
+import space.space_spring.dto.chat.CreateChatRoomResponse;
 import space.space_spring.dto.chat.ReadChatRoomResponse;
 import space.space_spring.entity.ChatRoom;
 import space.space_spring.entity.Space;
 import space.space_spring.entity.User;
+import space.space_spring.entity.UserChatRoom;
 import space.space_spring.util.space.SpaceUtils;
 import space.space_spring.util.user.UserUtils;
 
@@ -52,5 +56,26 @@ public class ChatRoomService {
                 })
                 .toList()
         );
+    }
+
+    @Transactional
+    public CreateChatRoomResponse createChatRoom(Long userId, Long spaceId, CreateChatRoomRequest createChatRoomRequest) {
+        // TODO 1: userId에 해당하는 user find
+        User userByUserId = userUtils.findUserByUserId(userId);
+
+        // TODO 2: spaceId에 해당하는 space find
+        Space spaceBySpaceId = spaceUtils.findSpaceBySpaceId(spaceId);
+
+        // TODO 3: chatRoom 생성 및 저장
+        ChatRoom chatRoom = chatRoomDao.save(ChatRoom.of(spaceBySpaceId, createChatRoomRequest));
+        log.info(chatRoom.toString());
+
+        // TODO 4: user_chatRoom 매핑 정보 저장
+        // TODO: 메시지 관련 처리 예정
+        UserChatRoom userChatRoom = userChatRoomDao.save(UserChatRoom.of(chatRoom, userByUserId, null));
+        log.info(userChatRoom.toString());
+
+        // TODO 5: chatroom id 반환
+        return CreateChatRoomResponse.of(chatRoom.getId());
     }
 }

--- a/src/main/java/space/space_spring/service/ChatRoomService.java
+++ b/src/main/java/space/space_spring/service/ChatRoomService.java
@@ -1,0 +1,56 @@
+package space.space_spring.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import space.space_spring.dao.UserDao;
+import space.space_spring.dao.chat.ChatRoomDao;
+import space.space_spring.dao.chat.UserChatRoomDao;
+import space.space_spring.dto.chat.ChatRoomResponse;
+import space.space_spring.dto.chat.ReadChatRoomResponse;
+import space.space_spring.entity.ChatRoom;
+import space.space_spring.entity.Space;
+import space.space_spring.entity.User;
+import space.space_spring.util.space.SpaceUtils;
+import space.space_spring.util.user.UserUtils;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+    private final UserDao userDao;
+    private final UserUtils userUtils;
+    private final SpaceUtils spaceUtils;
+    private final ChatRoomDao chatRoomDao;
+    private final UserChatRoomDao userChatRoomDao;
+
+    public ReadChatRoomResponse readChatRooms(Long userId, Long spaceId) {
+        // TODO 1: userId에 해당하는 user find
+        User userByUserId = userUtils.findUserByUserId(userId);
+
+        // TODO 2: spaceId에 해당하는 space find
+        Space spaceBySpaceId = spaceUtils.findSpaceBySpaceId(spaceId);
+
+        // TODO 3: 해당 user의 해당 space 내의 채팅방 리스트 select
+        List<ChatRoom> result = chatRoomDao.findByUserAndSpace(userByUserId, spaceBySpaceId);
+        log.info(result.toString());
+
+        return ReadChatRoomResponse.of(result.stream()
+                .map(cr -> {
+                    Long id = cr.getId();
+                    String name = cr.getName();
+                    String imgUrl = cr.getImg();
+                    // TODO: chatting message 처리
+                    // String lastMsg = cr.get
+                    String lastMsg = "메시지 관련 처리 예정";
+                    String lastTime = "메시지 관련 처리 예정";
+                    int unreadMsgCount = 1;
+                    return ChatRoomResponse.of(id, name, imgUrl, lastMsg, lastTime, unreadMsgCount);
+                })
+                .toList()
+        );
+    }
+}

--- a/src/main/java/space/space_spring/service/ChatRoomService.java
+++ b/src/main/java/space/space_spring/service/ChatRoomService.java
@@ -44,15 +44,11 @@ public class ChatRoomService {
 
         return ReadChatRoomResponse.of(result.stream()
                 .map(cr -> {
-                    Long id = cr.getId();
-                    String name = cr.getName();
-                    String imgUrl = cr.getImg();
                     // TODO: chatting message 처리
-                    // String lastMsg = cr.get
                     String lastMsg = "메시지 관련 처리 예정";
                     String lastTime = "메시지 관련 처리 예정";
                     int unreadMsgCount = 1;
-                    return ChatRoomResponse.of(id, name, imgUrl, lastMsg, lastTime, unreadMsgCount);
+                    return ChatRoomResponse.of(cr, lastMsg, lastTime, unreadMsgCount);
                 })
                 .toList()
         );

--- a/src/main/java/space/space_spring/util/userSpace/MemoryUserSpaceUtils.java
+++ b/src/main/java/space/space_spring/util/userSpace/MemoryUserSpaceUtils.java
@@ -9,6 +9,7 @@ import space.space_spring.dao.UserSpaceDao;
 import space.space_spring.entity.Space;
 import space.space_spring.entity.User;
 import space.space_spring.entity.UserSpace;
+import space.space_spring.entity.enumStatus.UserSpaceAuth;
 import space.space_spring.exception.UserSpaceException;
 
 import java.util.Optional;
@@ -31,5 +32,17 @@ public class MemoryUserSpaceUtils implements UserSpaceUtils {
 
         return Optional.ofNullable(userSpaceDao.findUserSpaceByUserAndSpace(userByUserId, spaceBySpaceId)
                 .orElseThrow(() -> new UserSpaceException(USER_IS_NOT_IN_SPACE)));
+    }
+
+    @Override
+    public boolean isUserManager(Long userId, Long spaceId) {
+        User userByUserId = userDao.findUserByUserId(userId);
+        Space spaceBySpaceId = spaceDao.findSpaceBySpaceId(spaceId);
+
+        // userId와 spaceId를 통해 UserSpace에서 권한 확인
+        Optional<UserSpace> userSpace = userSpaceDao.findUserSpaceByUserAndSpace(userByUserId, spaceBySpaceId);
+
+        String userSpaceAuth = userSpace.get().getUserSpaceAuth();
+        return userSpaceAuth.equals(UserSpaceAuth.MANAGER.getAuth());
     }
 }

--- a/src/main/java/space/space_spring/util/userSpace/MemoryUserSpaceUtils.java
+++ b/src/main/java/space/space_spring/util/userSpace/MemoryUserSpaceUtils.java
@@ -42,7 +42,10 @@ public class MemoryUserSpaceUtils implements UserSpaceUtils {
         // userId와 spaceId를 통해 UserSpace에서 권한 확인
         Optional<UserSpace> userSpace = userSpaceDao.findUserSpaceByUserAndSpace(userByUserId, spaceBySpaceId);
 
-        String userSpaceAuth = userSpace.get().getUserSpaceAuth();
-        return userSpaceAuth.equals(UserSpaceAuth.MANAGER.getAuth());
+        if (userSpace.isPresent()) {
+            String userSpaceAuth = userSpace.get().getUserSpaceAuth();
+            return userSpaceAuth.equals(UserSpaceAuth.MANAGER.getAuth());
+        }
+        return false;
     }
 }

--- a/src/main/java/space/space_spring/util/userSpace/UserSpaceUtils.java
+++ b/src/main/java/space/space_spring/util/userSpace/UserSpaceUtils.java
@@ -1,5 +1,6 @@
 package space.space_spring.util.userSpace;
 
+import space.space_spring.entity.User;
 import space.space_spring.entity.UserSpace;
 
 import java.util.Optional;
@@ -13,5 +14,6 @@ public interface UserSpaceUtils {
 
     Optional<UserSpace> isUserInSpace(Long userId, Long spaceId);
 
+    boolean isUserManager(Long userId, Long spaceId);
 
 }


### PR DESCRIPTION
## 📝 요약
이슈 번호 : #29 
채팅방 조회, 생성 및 참여 API 개발

## 🔖 변경 사항
- `QueryDSL`을 통한 쿼리 작성
- JpaRepository 인터페이스를 상속 및 커스텀하여 dao 생성
- 채팅방 생성 시 사진 및 권한 처리

## ✅ 리뷰 요구사항
채팅방 입장은 프론트에서 처리하는 부분이라
관련 자료들 노션 API 명세서에 첨부해놓았습니다

## 📸 확인 방법 (선택)
헤더에 `Authorization: Bearer {jwt}` 추가하고, API 명세서에 맞게 request 요청 시
다음과 같은 알맞은 response가 옵니다 (회원가입 후 스페이스 가입해야 테스트 가능)
<img width="1627" alt="스크린샷 2024-07-30 19 27 03" src="https://github.com/user-attachments/assets/f8a0a737-4541-4822-a70a-5348785259a5">
<img width="1629" alt="image" src="https://github.com/user-attachments/assets/3a243c36-73eb-4bfa-8102-a101f24b7f6b">
<img width="1627" alt="image" src="https://github.com/user-attachments/assets/de519849-fd5e-4552-a353-72d5634b7230">



<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
