### PR TITLE
Refactor/#44/스페이스 생성 api 에서 실제 이미지 데이터 저장

### DIFF
--- a/src/main/java/space/space_spring/dao/PayDao.java
+++ b/src/main/java/space/space_spring/dao/PayDao.java
@@ -18,14 +18,14 @@ public class PayDao {
     @PersistenceContext
     private EntityManager em;
 
-    public List<PayRequest> findPayRequestListByUser(User user, Space space) {
+    public List<PayRequest> findPayRequestListByUser(User user, Space space, boolean isComplete) {
         // 유저가 해당 스페이스에서 요청한 정산 목록만을 select
-        // 아직 정산이 완료되지 않은 payRequest 엔티티만 select
-        String jpql = "SELECT pr FROM PayRequest pr WHERE pr.payCreateUser = :user AND pr.space = :space AND pr.isComplete = false";
+        String jpql = "SELECT pr FROM PayRequest pr WHERE pr.payCreateUser = :user AND pr.space = :space AND pr.isComplete = :isComplete";
 
         return em.createQuery(jpql, PayRequest.class)
                 .setParameter("user", user)
                 .setParameter("space", space)
+                .setParameter("isComplete", isComplete)
                 .getResultList();
     }
 
@@ -39,16 +39,16 @@ public class PayDao {
                 .getResultList();
     }
 
-    public List<PayRequestTarget> findPayRequestTargetListByUser(User user, Space space) {
+    public List<PayRequestTarget> findPayRequestTargetListByUser(User user, Space space, boolean isComplete) {
         // 유저가 해당 스페이스에서 요청받은 정산 목록만을 select
-        // 유저가 요청받은 정산 중 아직 완료되지 않은 payRequestTarget 엔티티만 select
         String jpql = "SELECT prt FROM PayRequestTarget prt " +
                 "JOIN prt.payRequest pr " +
-                "WHERE prt.targetUserId = :userId AND pr.space = :space AND pr.isComplete = false";
+                "WHERE prt.targetUserId = :userId AND pr.space = :space AND pr.isComplete = :isComplete";
 
         return em.createQuery(jpql, PayRequestTarget.class)
                 .setParameter("userId", user.getUserId())
                 .setParameter("space", space)
+                .setParameter("isComplete", isComplete)
                 .getResultList();
     }
 

--- a/src/main/java/space/space_spring/dao/SpaceDao.java
+++ b/src/main/java/space/space_spring/dao/SpaceDao.java
@@ -16,9 +16,9 @@ public class SpaceDao {
     @PersistenceContext
     private EntityManager em;
 
-    public Space saveSpace(PostSpaceCreateRequest postSpaceCreateRequest) {
+    public Space saveSpace(String spaceName, String spaceImgUrl) {
         Space space = new Space();
-        space.saveSpace(postSpaceCreateRequest.getSpaceName(), postSpaceCreateRequest.getSpaceProfileImg());
+        space.saveSpace(spaceName, spaceImgUrl);
 
         em.persist(space);
         return space;

--- a/src/main/java/space/space_spring/dto/pay/GetRequestPayViewResponse.java
+++ b/src/main/java/space/space_spring/dto/pay/GetRequestPayViewResponse.java
@@ -1,0 +1,16 @@
+package space.space_spring.dto.pay;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class GetRequestPayViewResponse {
+
+    private List<PayRequestInfoDto> payRequestInfoDtoListInComplete = new ArrayList<>();
+
+    private List<PayRequestInfoDto> payRequestInfoDtoListComplete = new ArrayList<>();
+}

--- a/src/main/java/space/space_spring/dto/space/PostSpaceCreateRequest.java
+++ b/src/main/java/space/space_spring/dto/space/PostSpaceCreateRequest.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
@@ -16,5 +17,5 @@ public class PostSpaceCreateRequest {
     private String spaceName;
 
     @NotBlank(message = "스페이스 프로필 이미지는 공백일 수 없습니다.")
-    private String spaceProfileImg;         // 스페이스 프로필 이미지 (썸네일)
+    private MultipartFile spaceProfileImg;         // 스페이스 프로필 이미지 (썸네일)
 }

--- a/src/main/java/space/space_spring/dto/space/PostSpaceCreateRequest.java
+++ b/src/main/java/space/space_spring/dto/space/PostSpaceCreateRequest.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.web.multipart.MultipartFile;
+import space.space_spring.validator.ValidFile;
 
 @Getter
 @Setter
@@ -16,6 +17,6 @@ public class PostSpaceCreateRequest {
     @NotBlank(message = "스페이스 이름은 공백일 수 없습니다.")
     private String spaceName;
 
-    @NotBlank(message = "스페이스 프로필 이미지는 공백일 수 없습니다.")
+    @ValidFile(message = "스페이스 프로필 이미지는 공백일 수 없습니다.")
     private MultipartFile spaceProfileImg;         // 스페이스 프로필 이미지 (썸네일)
 }

--- a/src/main/java/space/space_spring/dto/space/PostSpaceCreateResponse.java
+++ b/src/main/java/space/space_spring/dto/space/PostSpaceCreateResponse.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class PostSpaceCreateResponse {
 
     private Long spaceId;
+    private String spaceImgUrl;         // 사진 url이 잘 생성됐는지 확인하는 용도
 }

--- a/src/main/java/space/space_spring/service/PayService.java
+++ b/src/main/java/space/space_spring/service/PayService.java
@@ -23,15 +23,15 @@ public class PayService {
     private final UserUtils userUtils;
     private final SpaceUtils spaceUtils;
 
-    public List<PayRequestInfoDto> getPayRequestInfoForUser(Long userId, Long spaceId) {
+    public List<PayRequestInfoDto> getPayRequestInfoForUser(Long userId, Long spaceId, boolean isComplete) {
         // TODO 1. userId에 해당하는 user find
         User userByUserId = userUtils.findUserByUserId(userId);
         
         // TODO 2. spaceId에 해당하는 space find
         Space spaceBySpaceId = spaceUtils.findSpaceBySpaceId(spaceId);
 
-        // TODO 3. 유저가 요청한 정산 중 진행 중인 정산 리스트 select
-        List<PayRequest> payRequestListByUser = payDao.findPayRequestListByUser(userByUserId, spaceBySpaceId);
+        // TODO 3. 유저가 요청한 정산 리스트 select
+        List<PayRequest> payRequestListByUser = payDao.findPayRequestListByUser(userByUserId, spaceBySpaceId, isComplete);
 
         // TODO 4. return 타입 구성
         // 3-1. 각 payRequest 에 해당하는 모든 payRequestTarget 을 loop로 돌면서 데이터 수집
@@ -62,15 +62,15 @@ public class PayService {
         return payRequestInfoDtoList;
     }
 
-    public List<PayReceiveInfoDto> getPayReceiveInfoForUser(Long userId, Long spaceId) {
+    public List<PayReceiveInfoDto> getPayReceiveInfoForUser(Long userId, Long spaceId, boolean isComplete) {
         // TODO 1. userId에 해당하는 유저 find
         User userByUserId = userUtils.findUserByUserId(userId);
 
         // TODO 2. spaceId에 해당하는 space find
         Space spaceBySpaceId = spaceUtils.findSpaceBySpaceId(spaceId);
         
-        // TODO 3. 유저가 요청받은 정산 중 진행 중인 정산 리스트 select
-        List<PayRequestTarget> payRequestTargetListByUser = payDao.findPayRequestTargetListByUser(userByUserId, spaceBySpaceId);
+        // TODO 3. 유저가 요청받은 정산 리스트 select
+        List<PayRequestTarget> payRequestTargetListByUser = payDao.findPayRequestTargetListByUser(userByUserId, spaceBySpaceId, isComplete);
 
         // TODO 4. return 타입 구성
         // 3-1. 각 payRequestTarget 에 해당하는 정산 요청자, 정산 요청 금액 을 loop를 돌면서 데이터 수집

--- a/src/main/java/space/space_spring/service/SpaceService.java
+++ b/src/main/java/space/space_spring/service/SpaceService.java
@@ -30,6 +30,6 @@ public class SpaceService {
         User manager = userDao.findUserByUserId(userId);
         UserSpace userSpace = userSpaceDao.createUserSpace(manager, saveSpace);
 
-        return new PostSpaceCreateResponse(saveSpace.getSpaceId());
+        return new PostSpaceCreateResponse(saveSpace.getSpaceId(), spaceImgUrl);
     }
 }

--- a/src/main/java/space/space_spring/service/SpaceService.java
+++ b/src/main/java/space/space_spring/service/SpaceService.java
@@ -21,10 +21,10 @@ public class SpaceService {
     private final UserSpaceDao userSpaceDao;
 
     @Transactional
-    public PostSpaceCreateResponse createSpace(Long userId, PostSpaceCreateRequest postSpaceCreateRequest) {
+    public PostSpaceCreateResponse createSpace(Long userId, String spaceName, String spaceImgUrl) {
 
         // TODO 1. 스페이스 생성 정보 db insert
-        Space saveSpace = spaceDao.saveSpace(postSpaceCreateRequest);
+        Space saveSpace = spaceDao.saveSpace(spaceName, spaceImgUrl);
 
         // TODO 2. 유저_스페이스 매핑 정보 db insert
         User manager = userDao.findUserByUserId(userId);

--- a/src/main/java/space/space_spring/validator/ValidFile.java
+++ b/src/main/java/space/space_spring/validator/ValidFile.java
@@ -1,0 +1,18 @@
+package space.space_spring.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidFileValidator.class)
+public @interface ValidFile {
+    String message() default "유효하지 않은 파일입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/space/space_spring/validator/ValidFileValidator.java
+++ b/src/main/java/space/space_spring/validator/ValidFileValidator.java
@@ -1,0 +1,14 @@
+package space.space_spring.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.web.multipart.MultipartFile;
+
+public class ValidFileValidator implements ConstraintValidator<ValidFile, MultipartFile> {
+
+    // multipartFile이 null 이 아니거나 비어있지 않으면 검증로직 통과
+    @Override
+    public boolean isValid(MultipartFile multipartFile, ConstraintValidatorContext constraintValidatorContext) {
+        return multipartFile != null && !multipartFile.isEmpty();
+    }
+}

--- a/src/test/java/space/space_spring/service/PayServiceTest.java
+++ b/src/test/java/space/space_spring/service/PayServiceTest.java
@@ -41,14 +41,20 @@ class PayServiceTest {
 
     private User user1;
     private User user2;
+    private User user3;
+    private User user4;
     private Space testSpace;
     private PayRequest testPayRequest;
-    private PayRequestTarget testPayRequestTarget;
+    private PayRequestTarget testPayRequestTarget_1;
+    private PayRequestTarget testPayRequestTarget_2;
+    private PayRequestTarget testPayRequestTarget_3;
 
     @BeforeEach
     public void 테스트_셋업() {
         /**
-         * user2이 같은 스페이스에 속한 user1에게 정산을 요청한 상황 가정
+         * user1이 같은 스페이스에 속한 user2, 3, 4 에게 정산을 요청한 상황 가정
+         * user 2, 3은 아직 정산 진행 중
+         * user 4 는 정산 완료
          */
         user1 = new User();
         user1.saveUser("test1@test.com", "abcDEF123!@", "user1", UserSignupType.LOCAL);
@@ -56,59 +62,101 @@ class PayServiceTest {
         user2 = new User();
         user2.saveUser("test2@test.com", "abcDEF123!@", "user2", UserSignupType.LOCAL);
 
+        user3 = new User();
+        user3.saveUser("test3@test.com", "abcDEF123!@", "user3", UserSignupType.LOCAL);
+
+        user4 = new User();
+        user4.saveUser("test4@test.com", "abcDEF123!@", "user4", UserSignupType.LOCAL);
+
         testSpace = new Space();
         testSpace.saveSpace("testSpace", "test_profile_img_url");
 
         testPayRequest = new PayRequest();
-        testPayRequest.savePayRequest(user2, testSpace, 30000, "우리은행", "111-111-111", false);
+        testPayRequest.savePayRequest(user1, testSpace, 30000, "우리은행", "111-111-111", false);
 
-        testPayRequestTarget = new PayRequestTarget();
-        testPayRequestTarget.savePayRequestTarget(testPayRequest, user1.getUserId(), 10000, false);
+        testPayRequestTarget_1 = new PayRequestTarget();
+        testPayRequestTarget_1.savePayRequestTarget(testPayRequest, user2.getUserId(), 10000, false);
+
+        testPayRequestTarget_2 = new PayRequestTarget();
+        testPayRequestTarget_2.savePayRequestTarget(testPayRequest, user3.getUserId(), 10000, false);
+
+        testPayRequestTarget_3 = new PayRequestTarget();
+        testPayRequestTarget_3.savePayRequestTarget(testPayRequest, user4.getUserId(), 10000, true);
+
     }
 
     @Test
-    @DisplayName("getPayRequestInfoForUser_메서드_테스트")
-    void 유저가_요청한_정산_중_진행중인_정산리스트_찾는_메서드_테스트() throws Exception {
+    @DisplayName("user1이_testSpace에서_요청한_정산중_현재진행중인_정산리스트_찾기")
+    void user1이_testSpace에서_요청한_정산중_현재진행중인_정산리스트_찾기() throws Exception {
         //given
-        when(userUtils.findUserByUserId(user2.getUserId())).thenReturn(user2);
+        when(userUtils.findUserByUserId(user1.getUserId())).thenReturn(user1);
         when(spaceUtils.findSpaceBySpaceId(testSpace.getSpaceId())).thenReturn(testSpace);
-        when(payDao.findPayRequestListByUser(user2, testSpace)).thenReturn(List.of(testPayRequest));
-        when(payDao.findPayRequestTargetListByPayRequest(testPayRequest)).thenReturn(List.of(testPayRequestTarget));
+        when(payDao.findPayRequestListByUser(user1, testSpace, false)).thenReturn(List.of(testPayRequest));
+        when(payDao.findPayRequestTargetListByPayRequest(testPayRequest)).thenReturn(List.of(testPayRequestTarget_1, testPayRequestTarget_2, testPayRequestTarget_3));
 
         //when
-        List<PayRequestInfoDto> payRequestInfoForUser = payService.getPayRequestInfoForUser(user2.getUserId(), testSpace.getSpaceId());
+        List<PayRequestInfoDto> payRequestInfoForUser = payService.getPayRequestInfoForUser(user2.getUserId(), testSpace.getSpaceId(), false);
 
         //then
         assertThat(payRequestInfoForUser.size()).isEqualTo(1);
 
         for (PayRequestInfoDto payRequestInfoDto : payRequestInfoForUser) {
             assertThat(payRequestInfoDto.getTotalAmount()).isEqualTo(30000);
-            assertThat(payRequestInfoDto.getReceiveAmount()).isEqualTo(0);
-            assertThat(payRequestInfoDto.getTotalTargetNum()).isEqualTo(1);
-            assertThat(payRequestInfoDto.getReceiveTargetNum()).isEqualTo(0);
+            assertThat(payRequestInfoDto.getReceiveAmount()).isEqualTo(10000);
+            assertThat(payRequestInfoDto.getTotalTargetNum()).isEqualTo(3);
+            assertThat(payRequestInfoDto.getReceiveTargetNum()).isEqualTo(1);
         }
     }
 
     @Test
-    @DisplayName("Test name")
-    void 유저가_요청받은_정산_중_진행중인_정산리스트_찾는_메서드_테스트() throws Exception {
+    @DisplayName("user2가_testSpace에서_요청받은_정산중_현재진행중인_정산리스트_찾기")
+    void user2가_testSpace에서_요청받은_정산중_현재진행중인_정산리스트_찾기() throws Exception {
         //given
-        when(userUtils.findUserByUserId(user1.getUserId())).thenReturn(user1);
+        when(userUtils.findUserByUserId(user2.getUserId())).thenReturn(user2);
         when(spaceUtils.findSpaceBySpaceId(testSpace.getSpaceId())).thenReturn(testSpace);
-        when(payDao.findPayRequestTargetListByUser(user1, testSpace)).thenReturn(List.of(testPayRequestTarget));
+        when(payDao.findPayRequestTargetListByUser(user2, testSpace, false)).thenReturn(List.of(testPayRequestTarget_1));
 
         //when
-        List<PayReceiveInfoDto> payReceiveInfoForUser = payService.getPayReceiveInfoForUser(user1.getUserId(), testSpace.getSpaceId());
+        List<PayReceiveInfoDto> payReceiveInfoForUser = payService.getPayReceiveInfoForUser(user1.getUserId(), testSpace.getSpaceId(), false);
 
         //then
         assertThat(payReceiveInfoForUser.size()).isEqualTo(1);
         for (PayReceiveInfoDto payReceiveInfoDto : payReceiveInfoForUser) {
-            assertThat(payReceiveInfoDto.getPayCreatorName()).isEqualTo(user2.getUserName());
+            assertThat(payReceiveInfoDto.getPayCreatorName()).isEqualTo(user1.getUserName());
             assertThat(payReceiveInfoDto.getRequestAmount()).isEqualTo(10000);
         }
     }
 
+    @Test
+    @DisplayName("user2가_testSpace에서_요청한_정산중_완료된_정산리스트_찾기")
+    void user2가_TestSpace에서_요청한_정산중_완료된_정산리스트_찾기() throws Exception {
+        //given
+        /**
+         * user2 가 testSpace에서 user1에게 정산을 요청 & 이 정산은 완료된 상황을 가정
+         */
+        PayRequest testPayRequest = new PayRequest();
+        testPayRequest.savePayRequest(user2, testSpace, 10000, "우리은행", "111-111-111", true);
+        PayRequestTarget testPayRequestTarget = new PayRequestTarget();
+        testPayRequestTarget.savePayRequestTarget(testPayRequest, user1.getUserId(), 10000, true);
 
+        when(userUtils.findUserByUserId(user2.getUserId())).thenReturn(user2);
+        when(spaceUtils.findSpaceBySpaceId(testSpace.getSpaceId())).thenReturn(testSpace);
+        when(payDao.findPayRequestListByUser(user2, testSpace, true)).thenReturn(List.of(testPayRequest));
+        when(payDao.findPayRequestTargetListByPayRequest(testPayRequest)).thenReturn(List.of(testPayRequestTarget));
+
+        //when
+        List<PayRequestInfoDto> payRequestInfoForUser = payService.getPayRequestInfoForUser(user2.getUserId(), testSpace.getSpaceId(), true);
+
+        //then
+        assertThat(payRequestInfoForUser.size()).isEqualTo(1);
+
+        for (PayRequestInfoDto payRequestInfoDto : payRequestInfoForUser) {
+            assertThat(payRequestInfoDto.getTotalAmount()).isEqualTo(10000);
+            assertThat(payRequestInfoDto.getReceiveAmount()).isEqualTo(10000);
+            assertThat(payRequestInfoDto.getTotalTargetNum()).isEqualTo(1);
+            assertThat(payRequestInfoDto.getReceiveTargetNum()).isEqualTo(1);
+        }
+    }
 
 
 }


### PR DESCRIPTION
## 📝 요약
기존 스페이스 생성 api는 썸네일 이미지의 url을 임의의 문자열로 지정해 db에 저장하였는데,
프론트단에서 직접 이미지 파일을 전달받아 aws s3에 저장하고 return 받은 url을 db에 저장하도록 코드를 수정하였습니다.

이슈 번호 : #44 

## 🔖 변경 사항
- json 형태가 아니라 form 데이터 형식으로 request dto를 전달받으므로, controller단에서 dto를 전달받을때 @ModelAttribute 어노테이션을 이용하도록 코드를 수정하였습니다.
- request dto로 받을 MultipartFile 타입 이미지 파일의 validation을 위해 ConstraintValidator 를 구현한 ValidFileValidator 를 추가하고, 이를 이용하기 위해 @ValidFile 어노테이션을 생성하였습니다.

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)
<img width="1689" alt="image" src="https://github.com/user-attachments/assets/2de52a3c-b680-4080-9fc4-5d15400d6a20">
postman으로 폼 데이터 형식의 request body를 구성하여 요청을 날리면, 응답으로 url 주소를 반환하도록 하였습니다.
이를 클릭하시면 요청보낼시에 입력한 이미지 파일을 확인할 수 있습니다.

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
