### PR TITLE
Feat/#67/스페이스 가입 view api

### DIFF
--- a/src/main/java/space/space_spring/controller/SpaceController.java
+++ b/src/main/java/space/space_spring/controller/SpaceController.java
@@ -7,6 +7,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import space.space_spring.argument_resolver.jwtLogin.JwtLoginAuth;
+import space.space_spring.dto.space.GetSpaceJoinDto;
 import space.space_spring.dto.space.response.GetUserInfoBySpaceResponse;
 import space.space_spring.dto.space.request.PostSpaceCreateRequest;
 
@@ -15,6 +16,7 @@ import space.space_spring.exception.SpaceException;
 import space.space_spring.response.BaseResponse;
 import space.space_spring.service.S3Uploader;
 import space.space_spring.service.SpaceService;
+import space.space_spring.util.userSpace.UserSpaceUtils;
 
 import java.io.IOException;
 
@@ -31,6 +33,7 @@ public class SpaceController {
     private final SpaceService spaceService;
     private final S3Uploader s3Uploader;
     private final String spaceImgDirName = "spaceImg";
+    private final UserSpaceUtils userSpaceUtils;
 
     @PostMapping("")
     public BaseResponse<String> createSpace(@JwtLoginAuth Long userId, @Validated @ModelAttribute PostSpaceCreateRequest postSpaceCreateRequest, BindingResult bindingResult) throws IOException {
@@ -69,6 +72,25 @@ public class SpaceController {
     public BaseResponse<GetUserInfoBySpaceResponse> getAllUserInfoBySpace(@PathVariable Long spaceId) {
 
         return new BaseResponse<>(spaceService.findUserInfoBySpace(spaceId));
+    }
+
+    /**
+     * 스페이스 가입 view를 위한 데이터 조회
+     */
+    @GetMapping("/{spaceId}/join")
+    public BaseResponse<GetSpaceJoinDto.Response> getSpaceJoin(@JwtLoginAuth Long userId, @PathVariable Long spaceId) {
+
+        // TODO 1. 유저가 이미 스페이스에 가입되어 있는 유저인지를 검증
+        validateIsUserAlreadySpaceMember(userId, spaceId);
+
+        // TODO 2. 초대할 스페이스의 정보를 return
+        return new BaseResponse<>(spaceService.findSpaceJoin(spaceId));
+    }
+
+    private void validateIsUserAlreadySpaceMember(Long userId, Long spaceId) {
+        // 유저가 이미 스페이스의 멤버일 경우 exception 발생
+        // exception 을 발생시키는 것이 아니라 response에 유저가 스페이스에 가입된 유저인지에 대한 정보를 포함하는게 더 좋을까??
+        userSpaceUtils.isUserAlreadySpaceMember(userId, spaceId);
     }
 
 }

--- a/src/main/java/space/space_spring/dao/SpaceDao.java
+++ b/src/main/java/space/space_spring/dao/SpaceDao.java
@@ -3,6 +3,7 @@ package space.space_spring.dao;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
+import space.space_spring.dto.space.GetSpaceJoinDto;
 import space.space_spring.entity.Space;
 
 @Repository
@@ -22,5 +23,4 @@ public class SpaceDao {
     public Space findSpaceBySpaceId(Long spaceId) {
         return em.find(Space.class, spaceId);
     }
-
 }

--- a/src/main/java/space/space_spring/dao/UserSpaceDao.java
+++ b/src/main/java/space/space_spring/dao/UserSpaceDao.java
@@ -108,4 +108,11 @@ public class UserSpaceDao {
         return userInfoInSpaceList;
     }
 
+    public int calculateSpaceMemberNum(Space space) {
+        String jpql = "SELECT COUNT(us) FROM UserSpace us WHERE us.space = :space AND us.status = 'ACTIVE'";
+        TypedQuery<Long> query = em.createQuery(jpql, Long.class);
+        query.setParameter("space", space);
+
+        return query.getSingleResult().intValue();
+    }
 }

--- a/src/main/java/space/space_spring/dto/space/GetSpaceJoinDto.java
+++ b/src/main/java/space/space_spring/dto/space/GetSpaceJoinDto.java
@@ -1,0 +1,29 @@
+package space.space_spring.dto.space;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class GetSpaceJoinDto {
+
+    private String spaceProfileImg;
+
+    private String spaceName;
+
+    private LocalDateTime createdAt;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Response {
+        private String spaceProfileImg;
+
+        private String spaceName;
+
+        private String createdAt;           // 스페이스 개설일의 정보를 yyyy년 mm월 dd일 형식으로 변환한 문자열
+
+        private int memberNum;
+    }
+}

--- a/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
@@ -67,7 +67,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
      */
     USER_IS_NOT_IN_SPACE(7000, HttpStatus.BAD_REQUEST.value(), "해당 스페이스에 속하지 않는 유저입니다."),
     UNAUTHORIZED_USER(7001, HttpStatus.UNAUTHORIZED.value(), "해당 스페이스에 관리자 권한이 없는 유저입니다."),
-    C(7002, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 닉네임입니다."),
+    USER_IS_ALREADY_IN_SPACE(7002, HttpStatus.BAD_REQUEST.value(), "해당 스페이스에 이미 가입되어 있는 유저입니다"),
     D(7003, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 회원입니다."),
     E(7004, HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
     F(7005, HttpStatus.BAD_REQUEST.value(), "잘못된 회원 status 값입니다."),

--- a/src/main/java/space/space_spring/service/SpaceService.java
+++ b/src/main/java/space/space_spring/service/SpaceService.java
@@ -6,11 +6,14 @@ import org.springframework.transaction.annotation.Transactional;
 import space.space_spring.dao.SpaceDao;
 import space.space_spring.dao.UserDao;
 import space.space_spring.dao.UserSpaceDao;
+import space.space_spring.dto.space.GetSpaceJoinDto;
 import space.space_spring.dto.space.response.GetUserInfoBySpaceResponse;
 import space.space_spring.entity.Space;
 import space.space_spring.entity.User;
 import space.space_spring.entity.UserSpace;
 import space.space_spring.util.space.SpaceUtils;
+
+import java.time.format.DateTimeFormatter;
 
 
 @Service
@@ -42,5 +45,33 @@ public class SpaceService {
 
         // TODO 2. 스페이스의 모든 유저 정보 return
         return new GetUserInfoBySpaceResponse(userSpaceDao.findUserInfoInSpace(spaceBySpaceId));
+    }
+
+    @Transactional
+    public GetSpaceJoinDto.Response findSpaceJoin(Long spaceId) {
+        // TODO 1. spaceId로 Space find
+        Space spaceBySpaceId = spaceUtils.findSpaceBySpaceId(spaceId);
+
+        // TODO 2. Space 엔티티에서 썸네일 이미지, 이름, 생성일 데이터 get
+        GetSpaceJoinDto getSpaceJoinDto = new GetSpaceJoinDto(
+                spaceBySpaceId.getSpaceProfileImg(),
+                spaceBySpaceId.getSpaceName(),
+                spaceBySpaceId.getCreatedAt()
+        );
+
+        // TODO 3. 해당 스페이스의 멤버 수 get
+        int memberNum = userSpaceDao.calculateSpaceMemberNum(spaceBySpaceId);
+
+        // TODO 4. 스페이스 생성일 형식 'yyyy년 mm월 dd일' 로 변경
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
+        String spaceCreatedDate = getSpaceJoinDto.getCreatedAt().format(formatter);
+
+        // TODO 5. return
+        return new GetSpaceJoinDto.Response(
+                getSpaceJoinDto.getSpaceProfileImg(),
+                getSpaceJoinDto.getSpaceName(),
+                spaceCreatedDate,
+                memberNum
+        );
     }
 }

--- a/src/main/java/space/space_spring/util/userSpace/MemoryUserSpaceUtils.java
+++ b/src/main/java/space/space_spring/util/userSpace/MemoryUserSpaceUtils.java
@@ -14,6 +14,7 @@ import space.space_spring.exception.UserSpaceException;
 
 import java.util.Optional;
 
+import static space.space_spring.response.status.BaseExceptionResponseStatus.USER_IS_ALREADY_IN_SPACE;
 import static space.space_spring.response.status.BaseExceptionResponseStatus.USER_IS_NOT_IN_SPACE;
 
 @Component
@@ -47,5 +48,18 @@ public class MemoryUserSpaceUtils implements UserSpaceUtils {
             return userSpaceAuth.equals(UserSpaceAuth.MANAGER.getAuth());
         }
         return false;
+    }
+
+    @Override
+    public void isUserAlreadySpaceMember(Long userId, Long spaceId) {
+        User userByUserId = userDao.findUserByUserId(userId);
+        Space spaceBySpaceId = spaceDao.findSpaceBySpaceId(spaceId);
+
+        // 해당 유저가 스페이스에 가입되어 있는지를 확인
+        Optional<UserSpace> userSpaceByUserAndSpace = userSpaceDao.findUserSpaceByUserAndSpace(userByUserId, spaceBySpaceId);
+
+        if (userSpaceByUserAndSpace.isPresent()) {
+            throw new UserSpaceException(USER_IS_ALREADY_IN_SPACE);
+        }
     }
 }

--- a/src/main/java/space/space_spring/util/userSpace/UserSpaceUtils.java
+++ b/src/main/java/space/space_spring/util/userSpace/UserSpaceUtils.java
@@ -16,4 +16,5 @@ public interface UserSpaceUtils {
 
     boolean isUserManager(Long userId, Long spaceId);
 
+    void isUserAlreadySpaceMember(Long userId, Long spaceId);
 }


### PR DESCRIPTION
## 📝 요약
스페이스 가입 view 를 위한 데이터를 response에 담아 보내주는 api 개발

이슈 번호 : #67 

## 🔖 변경 사항
jwt에 담긴 userId와 pathVariable 로 얻을 수 있는 spaceId로 해당 유저가 이미 스페이스에 가입되어 있는 유저인지를 검증하기 위한 코드를 컨트롤러단에 구성하였습니다.
현재는 이미 스페이스에 가입된 유저일 경우, 기존의 exception 과 동일하게 500 에러가 response로 전송됩니다
상준님이 개발하신 exception handler가 develop 브랜치에 머지되면, 이슈 생성 후 예외처리의 리펙토링을 진행하겠습니다

## ✅ 리뷰 요구사항
유저가 이미 스페이스에 가입되어 있는 경우, 예외처리를 통해 response로 4xx 예외를 보내는 방법과 response 에 해당 유저가 스페이스에 가입되어 있는 지의 여부를 나타내는 필드를 추가하는 방법 중 전자가 낫다는 판단하에 개발을 진행하였습니다.
컨트롤러 단에서 검증 로직을 통해 유저가 이미 스페이스에 가입되어 있는 경우, 굳이 스페이스 가입 view 를 위해 db 를 방문하여 데이터를 얻어오는 후작업을 할 필요가 없다고 판단했기 때문입니다.
혹시 다른 의견 있으시면 리뷰 남겨주세요!!

## 📸 확인 방법 (선택)
postman을 이용하여 유저가 스페이스에 가입되어 있지 않은 경우, 이미 가입된 경우의 결과를 확인하였습니다
리펙토링 시에 테스트 코드를 추가해보겠습니다

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
