### PR TITLE
[fix] 이미지 업로드 버그 수정 

### DIFF
--- a/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
@@ -88,7 +88,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
      */
 
     IS_NOT_IMAGE_FILE(9000, HttpStatus.BAD_REQUEST, "지원되는 이미지 파일의 형식이 아닙니다."),
-
+    MULTIPARTFILE_CONVERT_FAILE_IN_MEMORY(9001,HttpStatus.INTERNAL_SERVER_ERROR,"multipartFile memory 변환 과정에서 문제가 생겼습니다."),
     /*
      * 10000: voice room 오류
      */

--- a/src/main/java/space/space_spring/service/S3Uploader.java
+++ b/src/main/java/space/space_spring/service/S3Uploader.java
@@ -3,18 +3,23 @@ package space.space_spring.service;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import space.space_spring.exception.CustomException;
 import space.space_spring.validator.AllowedImageFileExtensions;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Optional;
+
+import static space.space_spring.response.status.BaseExceptionResponseStatus.MULTIPARTFILE_CONVERT_FAILE_IN_MEMORY;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -27,20 +32,39 @@ public class S3Uploader {
     private String bucket;
 
     //MultipartFile을 전달 받아 File로 전환 후 S3 업로드
-    public String upload(MultipartFile multipartFile, String dirName) throws IOException{// dirName의 디렉토리가 S3 Bucket 내부에 생성됨
+//    public String uploadFile(MultipartFile multipartFile, String dirName) throws IOException{// dirName의 디렉토리가 S3 Bucket 내부에 생성됨
+//
+//        File uploadFile = convert(multipartFile).orElseThrow(()-> new IllegalArgumentException("MultipartFile -> File 전환 실패"));
+//        //System.out.p
+//        // print("error: multipart file input. cant control");
+//        return upload(uploadFile,dirName);
+//    }
 
-        File uploadFile = convert(multipartFile).orElseThrow(()-> new IllegalArgumentException("MultipartFile -> File 전환 실패"));
-        //System.out.p
-        // print("error: multipart file input. cant control");
-        return upload(uploadFile,dirName);
-    }
-    public String upload(File uploadFile, String dirName){
-        String fileName = dirName+"/"+uploadFile.getName();
-        String uploadImageUrl = putS3(uploadFile,fileName);
+    // File에 저장하지 않고 Memory에서 변환 시행
+    public String upload(MultipartFile file, String dirName) throws IOException{
+        String fileName = dirName + "/" + file.getOriginalFilename();
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.getSize());
 
-        removeNewFile(uploadFile);// convert()함수로 인해서 로컬에 생성된 File 삭제 (MultipartFile -> File 전환 하며 로컬에 파일 생성됨)
-        return uploadImageUrl;
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata));
+            log.info("File uploaded successfully: {}", fileName);
+            return amazonS3Client.getUrl(bucket, fileName).toString();
+        } catch (IOException e) {
+            log.error("Error uploading file: {}", fileName, e);
+            throw new CustomException(MULTIPARTFILE_CONVERT_FAILE_IN_MEMORY,"Failed to upload file");
+        }
     }
+
+
+//    public String upload(File uploadFile, String dirName){
+//        String fileName = dirName+"/"+uploadFile.getName();
+//        String uploadImageUrl = putS3(uploadFile,fileName);
+//
+//        removeNewFile(uploadFile);// convert()함수로 인해서 로컬에 생성된 File 삭제 (MultipartFile -> File 전환 하며 로컬에 파일 생성됨)
+//        return uploadImageUrl;
+//    }
     // 업로드하기
     private String putS3(File uploadFile, String fileName){
         amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile)


### PR DESCRIPTION
download -> memory

## 📝 요약

이슈 번호 : #79 

## 원인
이미지 업로드 과정 중 `MultiPartFile`을 `File`로 변환하는 과정에서 이미지가 잠시 server 파일에 저장이 되는데, 이 과정에서 EC2에서 파일 쓰기 권한이 없어 발생한 오류 입니다.

## 해결 
이미지 변환 과정을 서버 파일에 저장하는 것이 아니라, 메모리에서 변환 과정을 수행합니다.

## 🔖 변경 사항
`S3UpLoader` 에서 upload 내부 함수만 수정했습니다.

## ✅ 리뷰 요구사항
local에서 확인 한번 해주시고 
진짜 되는지는 배포 되는 것을 확인해 봐야 할 것 같습니다.


---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
