### PR TITLE
HttpMessageNotReadable 예외 처리

### DIFF
--- a/src/main/java/space/space_spring/config/filter/RequestCachingFilter.java
+++ b/src/main/java/space/space_spring/config/filter/RequestCachingFilter.java
@@ -1,0 +1,21 @@
+package space.space_spring.config.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import java.io.IOException;
+@Component
+public class RequestCachingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+        filterChain.doFilter(wrappedRequest, response);
+    }
+}

--- a/src/main/java/space/space_spring/exceptionHandler/BaseExceptionControllerAdvice.java
+++ b/src/main/java/space/space_spring/exceptionHandler/BaseExceptionControllerAdvice.java
@@ -79,7 +79,7 @@ public class BaseExceptionControllerAdvice {
         String requestBody = getRequestBody(request);
 
 
-        return new BaseErrorResponse(SERVER_ERROR,"request body content : "+requestBody + " :content end");
+        return new BaseErrorResponse(HTTP_MESSAGE_NOT_READABLE,HTTP_MESSAGE_NOT_READABLE.getMessage()+" : request body content : "+requestBody + " :content end");
     }
 
     private String getRequestBody(HttpServletRequest request){

--- a/src/main/java/space/space_spring/exceptionHandler/BaseExceptionControllerAdvice.java
+++ b/src/main/java/space/space_spring/exceptionHandler/BaseExceptionControllerAdvice.java
@@ -1,17 +1,25 @@
 package space.space_spring.exceptionHandler;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.WebUtils;
 import space.space_spring.exception.BadRequestException;
 import space.space_spring.exception.InternalServerErrorException;
 import space.space_spring.response.BaseErrorResponse;
+
+import java.io.BufferedReader;
+import java.io.IOException;
 
 import static space.space_spring.response.status.BaseExceptionResponseStatus.*;
 
@@ -62,4 +70,36 @@ public class BaseExceptionControllerAdvice {
         log.error("[handle_RuntimeException]", e);
         return new BaseErrorResponse(SERVER_ERROR);
     }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler({HttpMessageNotReadableException.class, HttpMessageConversionException.class})
+    public BaseErrorResponse HttpNotReadableException(Exception e, HttpServletRequest request) {
+        log.error("[handle_RuntimeException]", e);
+
+        String requestBody = getRequestBody(request);
+
+
+        return new BaseErrorResponse(SERVER_ERROR,"request body content : "+requestBody + " :content end");
+    }
+
+    private String getRequestBody(HttpServletRequest request){
+        String requestBody = "";
+        ContentCachingRequestWrapper wrapper = WebUtils.getNativeRequest(request, ContentCachingRequestWrapper.class);
+        if (wrapper != null) {
+            byte[] buf = wrapper.getContentAsByteArray();
+            if (buf.length > 0) {
+                try {
+                    requestBody = new String(buf, 0, buf.length, wrapper.getCharacterEncoding());
+                } catch (IOException e) {
+                    // 예외 처리
+                    return "IO exception in parsing request body";
+                }
+            }
+        }
+
+
+        return requestBody.toString();
+
+    }
+
 }

--- a/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
@@ -18,6 +18,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     BAD_REQUEST(2000, HttpStatus.BAD_REQUEST, "유효하지 않은 요청입니다."),
     URL_NOT_FOUND(2001, HttpStatus.BAD_REQUEST, "유효하지 않은 URL 입니다."),
     METHOD_NOT_ALLOWED(2002, HttpStatus.METHOD_NOT_ALLOWED, "해당 URL에서는 지원하지 않는 HTTP Method 입니다."),
+    HTTP_MESSAGE_NOT_READABLE(2003, HttpStatus.BAD_REQUEST,"request body 양식에 문제가 있습니다"),
 
     /**
      * 3000: Server, Database 오류 (INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## 📝 요약

- 이슈 번호 : #97 
request JSON 형식에 문제가 생겼을 경우 발생하는 HttpMessageNotReadableException 처리를 추가했습니다.
해당 예외 발생시 error 코드와 request body에 무엇이 담겨 있었는지 함께 응답합니다.

## 🔖 변경 사항
- RequestCaching Fliter를 사용해서 Request body의 정보를 캐싱합니다.
- HttpNotReadableException 함수를 추가해 에러를 처리합니다.


## 📸 확인 방법 (선택)
![image](https://github.com/user-attachments/assets/0ee174a6-09ca-4e7a-b089-1d09adc76cdc)


---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
