### PR TITLE
[Refactoring] voice room 데이터 관련 리팩토링

### DIFF
--- a/src/main/java/space/space_spring/controller/VoiceRoomController.java
+++ b/src/main/java/space/space_spring/controller/VoiceRoomController.java
@@ -8,6 +8,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import space.space_spring.argumentResolver.jwtLogin.JwtLoginAuth;
 import space.space_spring.argumentResolver.userSpace.UserSpaceAuth;
+import space.space_spring.argumentResolver.userSpace.UserSpaceId;
 import space.space_spring.dao.UserSpaceDao;
 import space.space_spring.dao.VoiceRoomRepository;
 import space.space_spring.dto.VoiceRoom.*;
@@ -84,6 +85,7 @@ public class VoiceRoomController {
             @PathVariable("spaceId") @NotNull long spaceId,
             @JwtLoginAuth Long userId,
             @PathVariable("voiceRoomId") @NotNull Long roomId,
+            @UserSpaceId Long userSpaceId,
             HttpServletResponse response
     ){
 
@@ -92,7 +94,7 @@ public class VoiceRoomController {
         //해당 voiceRoom이 해당 space에 속한것이 맞는지 확인
         validateVoiceRoomInSpace(spaceId,roomId);
 
-        response.setHeader("Authorization", "Bearer " + voiceRoomService.getToken(spaceId, userId,roomId));
+        response.setHeader("Authorization", "Bearer " + voiceRoomService.getToken(spaceId, userId,userSpaceId,roomId));
         return new BaseResponse<String>(
             "보이스룸 토큰 생성에 성공했습니다."
         );

--- a/src/main/java/space/space_spring/dao/UserDao.java
+++ b/src/main/java/space/space_spring/dao/UserDao.java
@@ -51,7 +51,5 @@ public class UserDao {
     public User findUserByUserId(Long userId) {
         return em.find(User.class, userId);
     }
-    public String findProfileImageByUserId(Long userId){
-        return "Test ProfileImage URL";//findUserByUserId(userId).getProfileImage();
-    }
+
 }

--- a/src/main/java/space/space_spring/dao/UserSpaceDao.java
+++ b/src/main/java/space/space_spring/dao/UserSpaceDao.java
@@ -134,4 +134,11 @@ public class UserSpaceDao {
                 .getSingleResult();
 
     }
+
+    public Optional<String> findProfileImageById(Long userSpaceId){
+        String jpql = "SELECT us.userProfileImg FROM UserSpace us WHERE us.userSpaceId = :userSpaceId AND us.status = 'ACTIVE'";
+        return em.createQuery(jpql, String.class)
+                .setParameter("userSpaceId",userSpaceId)
+                .getResultList().stream().findFirst();
+    }
 }

--- a/src/main/java/space/space_spring/dao/UserSpaceDao.java
+++ b/src/main/java/space/space_spring/dao/UserSpaceDao.java
@@ -143,4 +143,12 @@ public class UserSpaceDao {
                 .getResultList();
         return result.isEmpty() ? Optional.empty() : Optional.ofNullable(result.get(0));
     }
+
+    public String findUserNameById(Long userSpaceId){
+        String jpql = "SELECT us.userName FROM UserSpace us WHERE us.userSpaceId = :userSpaceId AND us.status = 'ACTIVE'";
+        return em.createQuery(jpql, String.class)
+                .setParameter("userSpaceId", userSpaceId)
+                .getSingleResult();
+
+    }
 }

--- a/src/main/java/space/space_spring/dao/UserSpaceDao.java
+++ b/src/main/java/space/space_spring/dao/UserSpaceDao.java
@@ -14,6 +14,7 @@ import space.space_spring.entity.UserSpace;
 import space.space_spring.entity.enumStatus.UserSpaceAuth;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 import static space.space_spring.entity.enumStatus.UserSpaceAuth.MANAGER;
 
@@ -137,8 +138,9 @@ public class UserSpaceDao {
 
     public Optional<String> findProfileImageById(Long userSpaceId){
         String jpql = "SELECT us.userProfileImg FROM UserSpace us WHERE us.userSpaceId = :userSpaceId AND us.status = 'ACTIVE'";
-        return em.createQuery(jpql, String.class)
+        List<String> result = em.createQuery(jpql, String.class)
                 .setParameter("userSpaceId",userSpaceId)
-                .getResultList().stream().findFirst();
+                .getResultList();
+        return result.isEmpty() ? Optional.empty() : Optional.ofNullable(result.get(0));
     }
 }

--- a/src/main/java/space/space_spring/dao/VoiceRoomDao.java
+++ b/src/main/java/space/space_spring/dao/VoiceRoomDao.java
@@ -29,23 +29,6 @@ public class VoiceRoomDao  {
             return null;
         }
     }
-    @Transactional
-    public Integer findMaxOrderBySpace(Space space) {
-        String jpql = "SELECT MAX(r.order) FROM voice_room r WHERE r.space = :space";
-
-        return entityManager.createQuery(jpql, Integer.class)
-                .setParameter("space", space)
-                .getSingleResult();
-    }
-
-    @Transactional
-    public VoiceRoom findRoomWithMaxOrderBySpace(Space space) {
-        String jpql = "SELECT r FROM VoiceRoom r WHERE r.space = :space AND r.order = (SELECT MAX(r2.order) FROM VoiceRoom r2 WHERE r2.space = :space)";
-
-        return entityManager.createQuery(jpql, VoiceRoom.class)
-                .setParameter("space", space)
-                .getSingleResult();
-    }
 
 
 }

--- a/src/main/java/space/space_spring/dto/VoiceRoom/GetVoiceRoomList.java
+++ b/src/main/java/space/space_spring/dto/VoiceRoom/GetVoiceRoomList.java
@@ -36,6 +36,7 @@ public class GetVoiceRoomList {
         private int numParticipant;
         private int order;
         private List<GetParticipantList.ParticipantInfo> participantInfoList;
+        private String metadate;
 
         public static VoiceRoomInfo convertRoomDto(RoomDto roomDto){
             if(roomDto==null){return null;}
@@ -45,6 +46,7 @@ public class GetVoiceRoomList {
                     .Active(roomDto.getNumParticipants()!=0)
                     .numParticipant(roomDto.getNumParticipants())
                     .order(roomDto.getOrder())
+                    .metadate(roomDto.getMetadata())
                     .participantInfoList(
                             GetParticipantList.ParticipantInfo.convertParticipantDtoList(roomDto.getParticipantDTOList())
                     )

--- a/src/main/java/space/space_spring/dto/VoiceRoom/RoomDto.java
+++ b/src/main/java/space/space_spring/dto/VoiceRoom/RoomDto.java
@@ -97,7 +97,7 @@ public class RoomDto {
         if(liveKitRoomList==null||liveKitRoomList.isEmpty()){return;}
         boolean find = false;
         for(LivekitModels.Room resRoom : liveKitRoomList){
-            if(EqualRoomIdByNameTag(resRoom.getName(),this.id)){
+            if(String.valueOf(this.id).equals( resRoom.getName() )){
                 this.numParticipants = resRoom.getNumParticipants();
                 this.sid = resRoom.getSid();
                 this.metadata = resRoom.getMetadata();

--- a/src/main/java/space/space_spring/service/VoiceRoomService.java
+++ b/src/main/java/space/space_spring/service/VoiceRoomService.java
@@ -132,7 +132,7 @@ public class VoiceRoomService {
     }
     private List<ParticipantDto> getParticipantDtoListById(long voiceRoomId){
         Space space = voiceRoomRepository.findById(voiceRoomId).getSpace();
-        List<ParticipantDto> participantDtoList =  liveKitUtils.getParticipantInfo(findNameTagById(voiceRoomId));
+        List<ParticipantDto> participantDtoList =  liveKitUtils.getParticipantInfo(String.valueOf(voiceRoomId));
         if(participantDtoList==null||participantDtoList.isEmpty()){
             return Collections.emptyList();
         }
@@ -162,8 +162,10 @@ public class VoiceRoomService {
     public String getToken(long spaceId,long userId,long voiceRoomId){
         String userName=userDao.findUserByUserId(userId).getUserName();
         String userIdentity=String.valueOf(userId);
+        //Todo  profileImage 추가
         String metadata="";
-        String roomName=findNameTagById(voiceRoomId);
+        //String roomName=findNameTagById(voiceRoomId);
+        String roomName = String.valueOf(voiceRoomId);
         return liveKitUtils.getRoomToken(userName,userIdentity,roomName,metadata).toJwt();
     }
 }

--- a/src/main/java/space/space_spring/service/VoiceRoomService.java
+++ b/src/main/java/space/space_spring/service/VoiceRoomService.java
@@ -163,11 +163,10 @@ public class VoiceRoomService {
     }
 
     public String getToken(long spaceId,long userId,long userSpaceId,long voiceRoomId){
-        String userName=userDao.findUserByUserId(userId).getUserName();
+        String userName=userSpaceDao.findUserNameById(userSpaceId);
         String userIdentity=String.valueOf(userId);
         //Metadata에 profileImage와 userName 추가
-        String metadata="userProfileImage : "+userSpaceDao.findProfileImageById(userSpaceId).orElse("")
-                +", userName : "+userSpaceDao.findUserNameById(userSpaceId);
+        String metadata="userProfileImage : "+userSpaceDao.findProfileImageById(userSpaceId).orElse("");
         //String roomName=findNameTagById(voiceRoomId);
         String roomName = String.valueOf(voiceRoomId);
         return liveKitUtils.getRoomToken(userName,userIdentity,roomName,metadata).toJwt();

--- a/src/main/java/space/space_spring/service/VoiceRoomService.java
+++ b/src/main/java/space/space_spring/service/VoiceRoomService.java
@@ -165,8 +165,9 @@ public class VoiceRoomService {
     public String getToken(long spaceId,long userId,long userSpaceId,long voiceRoomId){
         String userName=userDao.findUserByUserId(userId).getUserName();
         String userIdentity=String.valueOf(userId);
-        //Todo  profileImage 추가
-        String metadata="userProfileImage : "+userSpaceDao.findProfileImageById(userSpaceId).orElse("");
+        //Metadata에 profileImage와 userName 추가
+        String metadata="userProfileImage : "+userSpaceDao.findProfileImageById(userSpaceId).orElse("")
+                +", userName : "+userSpaceDao.findUserNameById(userSpaceId);
         //String roomName=findNameTagById(voiceRoomId);
         String roomName = String.valueOf(voiceRoomId);
         return liveKitUtils.getRoomToken(userName,userIdentity,roomName,metadata).toJwt();

--- a/src/main/java/space/space_spring/service/VoiceRoomService.java
+++ b/src/main/java/space/space_spring/service/VoiceRoomService.java
@@ -162,11 +162,11 @@ public class VoiceRoomService {
         return name+" #"+String.valueOf(id);
     }
 
-    public String getToken(long spaceId,long userId,long voiceRoomId){
+    public String getToken(long spaceId,long userId,long userSpaceId,long voiceRoomId){
         String userName=userDao.findUserByUserId(userId).getUserName();
         String userIdentity=String.valueOf(userId);
         //Todo  profileImage 추가
-        String metadata="";
+        String metadata="userProfileImage : "+userSpaceDao.findProfileImageById(userSpaceId).orElse("");
         //String roomName=findNameTagById(voiceRoomId);
         String roomName = String.valueOf(voiceRoomId);
         return liveKitUtils.getRoomToken(userName,userIdentity,roomName,metadata).toJwt();

--- a/src/main/java/space/space_spring/service/VoiceRoomService.java
+++ b/src/main/java/space/space_spring/service/VoiceRoomService.java
@@ -12,6 +12,7 @@ import space.space_spring.dto.VoiceRoom.*;
 import space.space_spring.entity.Space;
 import space.space_spring.entity.User;
 import space.space_spring.entity.VoiceRoom;
+import space.space_spring.exception.CustomException;
 import space.space_spring.util.LiveKitUtils;
 import space.space_spring.util.space.SpaceUtils;
 import space.space_spring.util.user.UserUtils;
@@ -19,6 +20,8 @@ import space.space_spring.util.user.UserUtils;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import static space.space_spring.response.status.BaseExceptionResponseStatus.USER_IS_NOT_IN_SPACE;
 
 @Service
 @RequiredArgsConstructor
@@ -75,7 +78,7 @@ public class VoiceRoomService {
                 List<ParticipantDto> participantDtoList = getParticipantDtoListById(roomDto.getId());
                 for(ParticipantDto participantDto: participantDtoList){
                     //Todo profileIamge 집어넣기
-                    participantDto.setProfileImage(findProfileImageByUserId(participantDto.getId()));
+                    participantDto.setProfileImage(findProfileImageByUserId(participantDto.getUserSpaceId()));
                 }
                 //RoomDto에 값 집어넣기
                     //showParticipant = ture 일때, 참가자가 없으면 빈문자열[] 출력
@@ -121,8 +124,8 @@ public class VoiceRoomService {
         //Todo Base Entity에 일괄적으로 soft Delete를 적용하는 방법을 다같이 정하는 것이 좋아보임
     }
 
-    private String findProfileImageByUserId(Long userId){
-        return userDao.findProfileImageByUserId(userId);
+    private String findProfileImageByUserId(Long userSpaceId){
+        return userSpaceDao.findProfileImageById(userSpaceId).orElse("");
     }
     public List<VoiceRoom> findBySpaceId(long spaceId){
         return findBySpace(spaceUtils.findSpaceBySpaceId(spaceId));
@@ -138,7 +141,7 @@ public class VoiceRoomService {
         }
         for(ParticipantDto participantDto: participantDtoList){
             //profileIamge 집어넣기
-            participantDto.setProfileImage(findProfileImageByUserId(participantDto.getId()));
+            participantDto.setProfileImage(findProfileImageByUserId(participantDto.getUserSpaceId()));
             //userSpaceId 집어 넣기
             User user = userDao.findUserByUserId(participantDto.getId());
             participantDto.setUserSpaceId(userSpaceDao.findUserSpaceByUserAndSpace(user,space).get().getUserSpaceId());


### PR DESCRIPTION
## 📝 요약

- #100 
voiceRoom에서 정보 관련 저장 관련 코드를 리팩토링했습니다.
## 🔖 변경 사항
- livekit room name을 `roomName+#roomId`로 관리하던 방식을 `roomId`로 수정 했습니다. 이제 room의 이름을 수정하더라도, 같은 room으로 인식합니다.
- 참가자 profile image를 `response`와 liveKit Token `metadata`에 저장합니다. 백엔드 API, livekit API 로도 참가자의 프로필 이미지를 받아 올 수 있습니다.
- voiceRoom API에서 반환하던 userName을 userSpaceName으로 전부 변경했습니다. 해당 userSpaceDao 함수 또한 추가 하였습니다.

## 📸 확인 방법 (선택)
기존 방식으로 liveKit 참가 후, space-Profile 수정, voiceRoom 이름 수정 API를 사용해도, 정상 동작합니다.

단, 서버 API는 정보를 수정해도 일관성을 유지 하지만, LiveKit Token 정보는 중간에 수정 불가능합니다. 
LiveKit API로 받아온 정보는 수정해도 바뀌지 않습니다.



---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
