### PR TITLE
Hotfix/#127: 안읽은 메시지 버그 수정

### DIFF
--- a/src/main/java/space/space_spring/controller/ChatRoomController.java
+++ b/src/main/java/space/space_spring/controller/ChatRoomController.java
@@ -64,6 +64,17 @@ public class ChatRoomController {
     }
 
     /**
+     * 특정 유저가 채팅방에서 떠난 시간 저장
+     */
+    @PostMapping("/{chatRoomId}/leave")
+    public BaseResponse<ChatSuccessResponse> updateLastReadTime(
+            @JwtLoginAuth Long userId,
+            @PathVariable Long spaceId,
+            @PathVariable Long chatRoomId) {
+        return new BaseResponse<>(chatRoomService.updateLastReadTime(userId, spaceId, chatRoomId));
+    }
+
+    /**
      * 특정 채팅방의 모든 유저 정보 조회
      */
     @GetMapping("/{chatRoomId}/member")

--- a/src/main/java/space/space_spring/controller/ChattingController.java
+++ b/src/main/java/space/space_spring/controller/ChattingController.java
@@ -6,6 +6,8 @@ import org.springframework.context.event.EventListener;
 import org.springframework.messaging.handler.annotation.*;
 import org.springframework.messaging.simp.annotation.SubscribeMapping;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import space.space_spring.argumentResolver.userSpace.CheckUserSpace;
@@ -47,15 +49,15 @@ public class ChattingController {
     }
 
     // socket disconnect 시 호출
-    @EventListener
-    @CheckUserSpace(required = false)
-    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
-        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
-        Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
-
-        Long userId = (Long) sessionAttributes.get("userId");
-        Long chatRoomId = (Long) sessionAttributes.get("chatRoomId");
-
-        userChatRoomService.saveLastReadTime(userId, chatRoomId);
-    }
+//    @EventListener
+//    @CheckUserSpace(required = false)
+//    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+//        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+//        Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+//
+//        Long userId = (Long) sessionAttributes.get("userId");
+//        Long chatRoomId = (Long) sessionAttributes.get("chatRoomId");
+//        log.info("userId: " + userId + " chatRoomid: " + chatRoomId);
+//        userChatRoomService.saveLastReadTime(userId, chatRoomId);
+//    }
 }

--- a/src/main/java/space/space_spring/service/ChatRoomService.java
+++ b/src/main/java/space/space_spring/service/ChatRoomService.java
@@ -139,6 +139,20 @@ public class ChatRoomService {
     }
 
     @Transactional
+    public ChatSuccessResponse updateLastReadTime(Long userId, Long spaceId, Long chatRoomId) {
+        User userByUserId = userUtils.findUserByUserId(userId);
+        ChatRoom chatRoomByChatRoomId = chatRoomDao.findById(chatRoomId)
+                .orElseThrow(() -> new CustomException(CHATROOM_NOT_EXIST));
+
+        UserChatRoom targetChatRoom = userChatRoomDao.findByUserAndChatRoom(userByUserId, chatRoomByChatRoomId);
+        targetChatRoom.setLastReadTime(LocalDateTime.now());
+        userChatRoomDao.save(targetChatRoom);
+        log.info("userId: " + userId + " socket disconnect 시 마지막으로 읽은 시간: " + targetChatRoom.getLastReadTime());
+
+        return ChatSuccessResponse.of(true);
+    }
+
+    @Transactional
     public ChatSuccessResponse joinChatRoom(Long chatRoomId, JoinChatRoomRequest joinChatRoomRequest) {
         List<Long> memberIdList = joinChatRoomRequest.getMemberList();
         ChatRoom chatRoomByChatRoomId = chatRoomDao.findById(chatRoomId)
@@ -207,5 +221,4 @@ public class ChatRoomService {
         List<UserChatRoom> chatRoomList = userChatRoomDao.findByChatRoom(chatRoomByChatRoomId);
         return chatRoomList.stream().anyMatch(userChatRoom -> userChatRoom.getUser().equals(userByUserId));
     }
-
 }

--- a/src/main/java/space/space_spring/service/ChatRoomService.java
+++ b/src/main/java/space/space_spring/service/ChatRoomService.java
@@ -68,16 +68,19 @@ public class ChatRoomService {
                     if (lastMsg != null) {
                         lastUpdateTime = lastMsg.getCreatedAt();
                         lastContent = lastMsg.getContent();
+                        log.info("마지막으로 업데이트된 시간: " + lastUpdateTime + " 마지막으로 읽은 내용 : " + lastContent);
                     }
 
                     // TODO 6: 각 채팅방의 안읽은 메시지 개수 계산
                     UserChatRoom userChatRoom = userChatRoomDao.findByUserAndChatRoom(userByUserId, cr);
                     LocalDateTime lastReadTime = userChatRoom.getLastReadTime().atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+                    log.info("마지막으로 읽은 시간: " + lastReadTime);
                     int unreadMsgCount = chattingDao.countByChatRoomIdAndCreatedAtBetween(
                             cr.getId(),
                             lastReadTime,
                             lastUpdateTime
                     );
+                    log.info("안읽은 메시지 개수: " + unreadMsgCount);
 
                     return ChatRoomResponse.of(cr, lastContent, String.valueOf(lastUpdateTime), unreadMsgCount);
                 })

--- a/src/main/java/space/space_spring/service/UserChatRoomService.java
+++ b/src/main/java/space/space_spring/service/UserChatRoomService.java
@@ -33,6 +33,7 @@ public class UserChatRoomService {
         chatRoomByChatRoomId.ifPresent(chatRoom -> {
             UserChatRoom targetChatRoom = userChatRoomDao.findByUserAndChatRoom(userByUserId, chatRoom);
             targetChatRoom.setLastReadTime(LocalDateTime.now());
+            log.info("socket disconnect 시 마지막으로 읽은 시간" + targetChatRoom.getLastReadTime());
         });
     }
 }

--- a/src/main/java/space/space_spring/service/UserChatRoomService.java
+++ b/src/main/java/space/space_spring/service/UserChatRoomService.java
@@ -9,11 +9,14 @@ import space.space_spring.dao.chat.UserChatRoomDao;
 import space.space_spring.entity.ChatRoom;
 import space.space_spring.entity.User;
 import space.space_spring.entity.UserChatRoom;
+import space.space_spring.exception.CustomException;
 import space.space_spring.util.user.UserUtils;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Optional;
+
+import static space.space_spring.response.status.BaseExceptionResponseStatus.CHATROOM_NOT_EXIST;
 
 @Service
 @RequiredArgsConstructor
@@ -25,15 +28,15 @@ public class UserChatRoomService {
     private final ChatRoomDao chatRoomDao;
     private final UserChatRoomDao userChatRoomDao;
 
-    @Transactional
-    public void saveLastReadTime(Long userId, Long chatRoomId) {
-        User userByUserId = userUtils.findUserByUserId(userId);
-        Optional<ChatRoom> chatRoomByChatRoomId = chatRoomDao.findById(chatRoomId);
-
-        chatRoomByChatRoomId.ifPresent(chatRoom -> {
-            UserChatRoom targetChatRoom = userChatRoomDao.findByUserAndChatRoom(userByUserId, chatRoom);
-            targetChatRoom.setLastReadTime(LocalDateTime.now());
-            log.info("socket disconnect 시 마지막으로 읽은 시간" + targetChatRoom.getLastReadTime());
-        });
-    }
+//    @Transactional
+//    public void saveLastReadTime(Long userId, Long chatRoomId) {
+//        User userByUserId = userUtils.findUserByUserId(userId);
+//        ChatRoom chatRoomByChatRoomId = chatRoomDao.findById(chatRoomId)
+//                .orElseThrow(() -> new CustomException(CHATROOM_NOT_EXIST));
+//
+//        UserChatRoom targetChatRoom = userChatRoomDao.findByUserAndChatRoom(userByUserId, chatRoomByChatRoomId);
+//        targetChatRoom.setLastReadTime(LocalDateTime.now());
+////      userChatRoomDao.save(targetChatRoom);
+//        log.info("socket disconnect 시 마지막으로 읽은 시간" + targetChatRoom.getLastReadTime());
+//    }
 }


### PR DESCRIPTION
## 📝 요약
- resolved #127

## 🔖 변경 사항
socket disconnect 시에 세션에 저장된 userId와 chatRoomId를 통해, 유저가 채팅방을 떠난 시간을 저장하는 방식에서
유저가 채팅방을 떠날 때마다 http 요청을 보내면 서버에서 시간을 저장하는 로직으로 변경했습니다
비정상적인 disconnect가 발생한 경우에는 세션에 userId와 chatRoomId가 저장되어있지 않는 경우도 있는 것 같아서
해당 경우엔 userId로 user를 찾지 못하므로 불필요한 서버 오류가 많아지는 것 같아서 좀 더 확실한 방식을 선택했습니다
좋은 의견 있으시면 남겨주세요

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
