### PR TITLE
Feat/#96/voice room livekit api 병렬 처리 

### DIFF
--- a/src/main/java/space/space_spring/config/ThreadPoolConfig.java
+++ b/src/main/java/space/space_spring/config/ThreadPoolConfig.java
@@ -14,9 +14,9 @@ public class ThreadPoolConfig {
     public TaskExecutor threadPoolTaskExecutor(){
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         int JVMCore = Runtime.getRuntime().availableProcessors();
-        executor.setCorePoolSize(5); // 기본적으로 생성할 스레드 수
-        executor.setMaxPoolSize(10); // 최대 스레드 수
-        executor.setQueueCapacity(50); // 큐의 크기 (요청이 초과되면 큐에 대기)
+        executor.setCorePoolSize(JVMCore <= 50 ? JVMCore : 50); // 기본적으로 생성할 스레드 수
+        executor.setMaxPoolSize(JVMCore); // 최대 스레드 수
+        executor.setQueueCapacity(200); // 큐의 크기 (요청이 초과되면 큐에 대기)
         executor.setThreadNamePrefix("CustomExecutor-"); // 스레드 이름 접두사
         executor.setWaitForTasksToCompleteOnShutdown(true);//어플리케이션 종료시 작업 완료 대기
         executor.setAwaitTerminationSeconds(20);//최대 종료 대기 시간

--- a/src/main/java/space/space_spring/config/ThreadPoolConfig.java
+++ b/src/main/java/space/space_spring/config/ThreadPoolConfig.java
@@ -1,0 +1,26 @@
+package space.space_spring.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class ThreadPoolConfig {
+
+    @Bean
+    @Primary
+    public TaskExecutor threadPoolTaskExecutor(){
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        int JVMCore = Runtime.getRuntime().availableProcessors();
+        executor.setCorePoolSize(5); // 기본적으로 생성할 스레드 수
+        executor.setMaxPoolSize(10); // 최대 스레드 수
+        executor.setQueueCapacity(50); // 큐의 크기 (요청이 초과되면 큐에 대기)
+        executor.setThreadNamePrefix("CustomExecutor-"); // 스레드 이름 접두사
+        executor.setWaitForTasksToCompleteOnShutdown(true);//어플리케이션 종료시 작업 완료 대기
+        executor.setAwaitTerminationSeconds(20);//최대 종료 대기 시간
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/space/space_spring/controller/LiveKitController.java
+++ b/src/main/java/space/space_spring/controller/LiveKitController.java
@@ -73,4 +73,5 @@ public class LiveKitController {
         }
     }
 
+
 }

--- a/src/main/java/space/space_spring/controller/VoiceRoomController.java
+++ b/src/main/java/space/space_spring/controller/VoiceRoomController.java
@@ -75,7 +75,24 @@ public class VoiceRoomController {
 
         GetVoiceRoomList.Request voiceRoomList=new GetVoiceRoomList.Request(limit, showParticipant);
 
-        List<GetVoiceRoomList.VoiceRoomInfo> roomInfoList = voiceRoomService.getVoiceRoomInfoList(spaceId,voiceRoomList);
+        List<GetVoiceRoomList.VoiceRoomInfo> roomInfoList = voiceRoomService.getVoiceRoomInfoListConcurrency(spaceId,voiceRoomList);
+        return new BaseResponse<GetVoiceRoomList.Response>(new GetVoiceRoomList.Response(roomInfoList));
+    }
+
+    @GetMapping("/test")
+    public BaseResponse<GetVoiceRoomList.Response> getRoomListNonConCurrent(
+            @PathVariable("spaceId") @NotNull long spaceId,
+            @JwtLoginAuth Long userId,
+            //@RequestBody GetVoiceRoomList.Request voiceRoomList,
+            @RequestParam(required = false,defaultValue = "0") Integer limit,
+            @RequestParam(required = false,defaultValue = "false") Boolean showParticipant){
+
+        boolean showParticipantValue = (showParticipant != null) ? showParticipant : false;
+
+
+        GetVoiceRoomList.Request voiceRoomList=new GetVoiceRoomList.Request(limit, showParticipant);
+
+        List<GetVoiceRoomList.VoiceRoomInfo> roomInfoList = voiceRoomService.getVoiceRoomInfoListConcurrency(spaceId,voiceRoomList);
         return new BaseResponse<GetVoiceRoomList.Response>(new GetVoiceRoomList.Response(roomInfoList));
     }
 

--- a/src/main/java/space/space_spring/controller/VoiceRoomController.java
+++ b/src/main/java/space/space_spring/controller/VoiceRoomController.java
@@ -79,20 +79,33 @@ public class VoiceRoomController {
         return new BaseResponse<GetVoiceRoomList.Response>(new GetVoiceRoomList.Response(roomInfoList));
     }
 
-    @GetMapping("/test")
+    @GetMapping("/con/{version}")
     public BaseResponse<GetVoiceRoomList.Response> getRoomListNonConCurrent(
             @PathVariable("spaceId") @NotNull long spaceId,
             @JwtLoginAuth Long userId,
             //@RequestBody GetVoiceRoomList.Request voiceRoomList,
             @RequestParam(required = false,defaultValue = "0") Integer limit,
-            @RequestParam(required = false,defaultValue = "false") Boolean showParticipant){
+            @RequestParam(required = false,defaultValue = "false") Boolean showParticipant,
+            @PathVariable("version") Integer version){
 
         boolean showParticipantValue = (showParticipant != null) ? showParticipant : false;
 
 
         GetVoiceRoomList.Request voiceRoomList=new GetVoiceRoomList.Request(limit, showParticipant);
+        List<GetVoiceRoomList.VoiceRoomInfo> roomInfoList;
+        if(version==null){
+            version =1;
+        }
+        if(version==1){
+            roomInfoList= voiceRoomService.getVoiceRoomInfoListConcurrency(spaceId,voiceRoomList);
+        }
+        if(version==2){
+            roomInfoList = voiceRoomService.getVoiceRoomInfoList(spaceId,voiceRoomList);
+        }
+        else{
+            roomInfoList= voiceRoomService.getVoiceRoomInfoListConcurrency(spaceId,voiceRoomList);
+        }
 
-        List<GetVoiceRoomList.VoiceRoomInfo> roomInfoList = voiceRoomService.getVoiceRoomInfoListConcurrency(spaceId,voiceRoomList);
         return new BaseResponse<GetVoiceRoomList.Response>(new GetVoiceRoomList.Response(roomInfoList));
     }
 

--- a/src/main/java/space/space_spring/dto/VoiceRoom/RoomDto.java
+++ b/src/main/java/space/space_spring/dto/VoiceRoom/RoomDto.java
@@ -32,8 +32,9 @@ public class RoomDto {
                 .map(ParticipantDto::convertParticipant)
                 .collect(Collectors.toList());
     }
-    public void setParticipantDTOList(List<ParticipantDto> participantDtoList){
+    public RoomDto setParticipantDTOList(List<ParticipantDto> participantDtoList){
         this.participantDTOList =  participantDtoList;
+        return this;
     }
 
     public static RoomDto convertRoom(LivekitModels.Room room){
@@ -108,6 +109,7 @@ public class RoomDto {
 
         }
         if(!find){this.numParticipants=0;}
+        //return this;
     }
     private static boolean EqualRoomIdByNameTag(String roomName,long Id){
         return roomName.endsWith("#"+String.valueOf(Id));

--- a/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/response/status/BaseExceptionResponseStatus.java
@@ -97,7 +97,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     INVALID_VOICEROOM_REQUEST(10002, HttpStatus.BAD_REQUEST,"잘못된 요청 인자 입니다."),
 
     VOICEROOM_NAME_ALREADY_EXIST(10003, HttpStatus.BAD_REQUEST,"이미 존재하는 VoiceRoom 이름 입니다."),
-    VOICEROOM_NOT_IN_SPACE(10004, HttpStatus.BAD_REQUEST,"이미 존재하는 VoiceRoom 이름 입니다."),
+    VOICEROOM_NOT_IN_SPACE(10004, HttpStatus.BAD_REQUEST,"해당 스페이스에 없는 보이스 룸입니다."),
 
     /**
      * 11000: Post 오류

--- a/src/main/java/space/space_spring/service/VoiceRoomService.java
+++ b/src/main/java/space/space_spring/service/VoiceRoomService.java
@@ -137,7 +137,10 @@ public class VoiceRoomService {
             roomDto.setActiveRoom(roomResponses);
         }
         List<CompletableFuture<Void>> roomDtoFutureList = roomDtoList.stream()
-                .map(r->CompletableFuture.runAsync(()->setRoomDto(r,roomResponses,req),taskExecutor)).collect(Collectors.toList());
+                .map(r->CompletableFuture.runAsync(()->setRoomDto(r,roomResponses,req),taskExecutor)
+                        //.exceptionally(ex->{throws ex;})
+                )
+                .collect(Collectors.toList());
 
 
         // 모든 Future의 완료를 기다림

--- a/src/test/java/space/space_spring/concurrency/completableFutureTest.java
+++ b/src/test/java/space/space_spring/concurrency/completableFutureTest.java
@@ -1,0 +1,115 @@
+package space.space_spring.concurrency;
+
+import livekit.LivekitModels;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import space.space_spring.dao.VoiceRoomRepository;
+import space.space_spring.dto.VoiceRoom.RoomDto;
+import space.space_spring.entity.Space;
+import space.space_spring.entity.VoiceRoom;
+import org.mockito.Mock;
+import org.mockito.InjectMocks;
+import space.space_spring.util.LiveKitUtils;
+import space.space_spring.util.space.SpaceUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.when;
+
+
+public class completableFutureTest {
+    @Test
+    void runAsync() throws ExecutionException, InterruptedException {
+        CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+            try{Thread.sleep(1000L);}catch (InterruptedException e){}
+            System.out.println("Thread: " + Thread.currentThread().getName());
+        });
+        System.out.println("Before call Get ");
+        future.get();
+        System.out.println("Thread: " + Thread.currentThread().getName());
+    }
+    // 출처: https://mangkyu.tistory.com/263 [MangKyu's Diary:티스토리]
+
+    @Test
+    void supplyAsync() throws ExecutionException, InterruptedException {
+
+        CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
+            try{Thread.sleep(1000L);}catch (InterruptedException e){}
+            return "Thread: " + Thread.currentThread().getName();
+        });
+
+        System.out.println(future.get());
+        System.out.println("Thread: " + Thread.currentThread().getName());
+    }
+    //출처: https://mangkyu.tistory.com/263 [MangKyu's Diary:티스토리]
+
+    @Test
+    public void ThreadAfterThread(){
+        List<String> strings = List.of("Hi", "CompletableFuture", "OK", "Processing");
+
+        List<CompletableFuture<Integer>> futures = processStringsAsync(strings);
+
+        // 모든 Future의 완료를 기다림
+        CompletableFuture<Void> allOf = CompletableFuture.allOf(
+                futures.toArray(new CompletableFuture[0]));
+
+        // 결과 수집 및 출력
+        allOf.thenRun(() -> {
+            List<Integer> results = futures.stream()
+                    .map(CompletableFuture::join)
+                    .collect(Collectors.toList());
+            System.out.println("Processed string lengths: " + results);
+        }).join();
+
+        // 개별 결과 출력 (순서 무관)
+        for (int i = 0; i < strings.size(); i++) {
+            final int index = i;
+            futures.get(i).thenAccept(result ->
+                    System.out.println("Result for '" + strings.get(index) + "': " + result)
+            );
+        }
+    }
+    public static List<CompletableFuture<Integer>> processStringsAsync(List<String> strings) {
+        return strings.stream()
+                .map(s -> CompletableFuture.supplyAsync(() -> s.length())
+                        .thenCompose(length -> CompletableFuture.supplyAsync(()->length <= 3 ? length * 10 : length)))
+                .collect(Collectors.toList());
+    }
+    @Mock
+    private VoiceRoomRepository repository;
+    @Mock
+    private SpaceUtils spaceUtils;
+    @Mock
+    private LiveKitUtils liveKitUtils;
+    @ParameterizedTest
+    @ValueSource(booleans =  {true, false})
+    public void getRoomListTest(boolean showParticipant){
+        long spaceId = 1;
+        Space space1 = new Space();
+        space1.saveSpace("space1","asdf");
+        VoiceRoom voiceRoom1= VoiceRoom.createVoiceRoom("room1",1,space1);
+        VoiceRoom voiceRoom2= VoiceRoom.createVoiceRoom("room2",2,space1);
+        VoiceRoom voiceRoom3= VoiceRoom.createVoiceRoom("room3",3,space1);
+        List<VoiceRoom> voiceRoomList= List.of(voiceRoom1,voiceRoom2,voiceRoom3);
+        List<LivekitModels.Room> roomList = new ArrayList<LivekitModels.Room>();
+        //roomList.add(LivekitModels.Room.newBuilder())
+        //private static List<VoiceRoom> findBySpace(long userID){return null;}
+        when(spaceUtils.findSpaceBySpaceId(spaceId)).thenReturn(space1);
+        when(repository.findBySpace(spaceUtils.findSpaceBySpaceId(spaceId))).thenReturn(voiceRoomList);
+        //when(liveKitUtils.getRoomList()).thenReturn()
+
+        List<VoiceRoom> voiceRoomDataList = repository.findBySpace(spaceUtils.findSpaceBySpaceId(spaceId));
+        List<RoomDto> roomDtoList = RoomDto.convertRoomDtoListByVoiceRoom(voiceRoomDataList);
+
+
+
+    }
+
+
+
+}

--- a/src/test/java/space/space_spring/concurrency/completableFutureTest.java
+++ b/src/test/java/space/space_spring/concurrency/completableFutureTest.java
@@ -80,35 +80,7 @@ public class completableFutureTest {
                         .thenCompose(length -> CompletableFuture.supplyAsync(()->length <= 3 ? length * 10 : length)))
                 .collect(Collectors.toList());
     }
-    @Mock
-    private VoiceRoomRepository repository;
-    @Mock
-    private SpaceUtils spaceUtils;
-    @Mock
-    private LiveKitUtils liveKitUtils;
-    @ParameterizedTest
-    @ValueSource(booleans =  {true, false})
-    public void getRoomListTest(boolean showParticipant){
-        long spaceId = 1;
-        Space space1 = new Space();
-        space1.saveSpace("space1","asdf");
-        VoiceRoom voiceRoom1= VoiceRoom.createVoiceRoom("room1",1,space1);
-        VoiceRoom voiceRoom2= VoiceRoom.createVoiceRoom("room2",2,space1);
-        VoiceRoom voiceRoom3= VoiceRoom.createVoiceRoom("room3",3,space1);
-        List<VoiceRoom> voiceRoomList= List.of(voiceRoom1,voiceRoom2,voiceRoom3);
-        List<LivekitModels.Room> roomList = new ArrayList<LivekitModels.Room>();
-        //roomList.add(LivekitModels.Room.newBuilder())
-        //private static List<VoiceRoom> findBySpace(long userID){return null;}
-        when(spaceUtils.findSpaceBySpaceId(spaceId)).thenReturn(space1);
-        when(repository.findBySpace(spaceUtils.findSpaceBySpaceId(spaceId))).thenReturn(voiceRoomList);
-        //when(liveKitUtils.getRoomList()).thenReturn()
 
-        List<VoiceRoom> voiceRoomDataList = repository.findBySpace(spaceUtils.findSpaceBySpaceId(spaceId));
-        List<RoomDto> roomDtoList = RoomDto.convertRoomDtoListByVoiceRoom(voiceRoomDataList);
-
-
-
-    }
 
 
 


### PR DESCRIPTION
## 📝 요약
- #96 

기존 getRoomList API는 voiceRoom list를 처리하는 과정에서 LiveKit API를 호출합니다.
이때 요청/응답 과정이 각 Room에 대해서 발생해서 getRoomList API 응답 속도가 느립니다.(특히 참가자 정보를 포함한 요청)
이를 멀티 스레드를 사용해 병렬 처리하여 속도를 개선했습니다.


## 🔖 변경 사항
### 주요 변경사항
- **기존 함수에 병렬 처리가 적용된 `getVoiceRoomInfoConcurrency` 함수를 추가했습니다.**
- **CompletableFuture 를 사용해서 멀티 쓰레드를 구현**
- **ThreadPoolConfig를 사용해 ThreadPool 관리**

### 부가 변경사항
- "/con/2" URL을 사용해서 기존 함수도 접근가능 (비상용)
-  `VOICEROOM_NOT_IN_SPACE` 에러 메세지 수정
-  CompletableFuture Test : Computable 객체를 알아보기 위한 코드들

## ✅ 리뷰 요구사항
배포 후에 VoiceRoom 사용량이 많은 상황에서 검증을 해봐야합니다
솔직히 안정성에 있어서 자신이 없습니다.

## 📸 개선
### 환경
voiceRoom 20개
참가자가 포함된 voiceRoom 10개 

### 결과 
![image](https://github.com/user-attachments/assets/a58f78d4-e733-4770-9233-4ba3b4627cd8)
_기존 getRoomList API ( 참가자 정보 포함)_
![image](https://github.com/user-attachments/assets/361ba1d9-7220-4f01-bfa2-35e454f972e4)
_병렬 처리가 적용된 getRoomList API ( 참가자 정보 포함)_

기존 API는 room의 개수( 참가자가 존재하는 room )가 늘어날 수록 비례해서 응답시간이 증가 했습니다.
현재 병렬처리가 적용된 API는 기존 API에 비해 **약 3배** 향상된 성능을 보입니다. (위 경우에서는)
사용자들이 늘어나고, 동시 접속 중인 voiceRoom의 개수가 늘어나면, 더 향상될 것으로 보입니다.
<br/>

## 추가 개선 사항
단 참가중인 vociceRoom이 많지 않을 경우( 2개 이하) 에서는 성능의 차이가 크지 않은 것으로 보입니다.

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
