### PR TITLE
Chore : RDS 전환, CD application.yml 주입 수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -113,7 +113,7 @@ jobs:
 
     - name: Set YML
       run: |
-        echo "${{ secrets.APPLICATION_YML_DEV }}" | base64 --decode > src/main/resources/application.yml
+        echo "${{ secrets.APPLICATION_YML_DEV }}" > src/main/resources/application.yml
 
       # (5) Gradle build (Test 제외)
     - name: Build with Gradle


### PR DESCRIPTION
## 📝 요약

- 이슈 번호 : #149 
application.yml 파일 주입 방식을 base64 암호화 방식에서 일반 파일 주입 방식으로 변경
RDS를 퍼블릭 IPv4에서 서브넷 내부방 방식으로 전환
## 🔖 변경 사항
- application.yml을 base64로 암호화해서 주입하지 않아도 됩니다.
- RDS가 전환 되었습니다. 기존 데이터가 초기화 됩니다.
- 외부에서 DB 접근이 불가능합니다.

CI/CD gitHub Action flow를 요구사항대로 변경하지 못했습니다.
1. 이중 CI 문제를 해결하기 위해 on.pull request.main을 삭제했으나, 2중 CI는 해결했지만, CI가 아예 진행되지 않고, 이전 Push CI 정보를 그대로 사용하는 것을 확인했습니다. 안정성을 위해서 기존 방식을 유지하기로 했습니다.
develop->main 으로 PR을 생성 할 시 CI action과정이 2번 표기됩니다.(실제로는 1번)
2. [chore/**] branch를 devlop에 merge(push)시에만 deploy action이 진행되는 것으로 설정 하려 했으나, gitHub Action에서 push시에 source branch 추적 기능을 제공해 주지 않아 구현이 복잡합니다. 안정성을 위해 기존 방법을 유지합니다.
"chore/"로 시작하는 브랜치를 "develop"에 PR을 생성하는 시점에 바로 deploy가 진행됩니다.
 

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
