### PR TITLE
Feat/#185/jda config bean 등록

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,15 @@ dependencies {
 
 	//Spring Security Test 의존성
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	//JDA
+	implementation("net.dv8tion:JDA:5.2.1") { // replace $version with the latest version
+		// Optionally disable audio natives to reduce jar size by excluding `opus-java`
+		// Gradle DSL:
+		// exclude module: 'opus-java'
+		// Kotlin DSL:
+		// exclude(module="opus-java")
+	}
 }
 
 test {

--- a/src/main/java/space/space_spring/domain/discord/adapter/in/discord/SlashCommandEventListener.java
+++ b/src/main/java/space/space_spring/domain/discord/adapter/in/discord/SlashCommandEventListener.java
@@ -1,0 +1,60 @@
+package space.space_spring.domain.discord.adapter.in.discord;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class SlashCommandEventListener extends ListenerAdapter {
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        // Only accept commands from guilds
+        if (event.getGuild() == null)
+            return;
+        switch (event.getName()) {
+            case "guildinfo":
+                Guild guild = event.getGuild();
+                String Guild_info = "Guild-info" +
+                        "\nGuild-ID : " + guild.getId() +
+                        "\nChannel : " + guild.getChannels().size() +
+                        "\nmembers : " + guild.getMembers().size() +
+                        "\nthis Channel ID(temp) : " + event.getChannel().getId().toString();
+                String channelList = " \nchannels";
+                List<GuildChannel> channels = guild.getChannels();
+                for (GuildChannel guildChannel : channels) {
+                    channelList = channelList + "\n" + guildChannel.getName() + " : " + guildChannel.getId().toString();
+                }
+                Guild_info = Guild_info + channelList;
+                reply(event, Guild_info);
+                //guild.loadMembers(member -> {say(event,member.getEffectiveName()+"\n");});
+
+                break;
+            case "Member-info":
+                String MemberInfo = "Guild Member Info";
+                event.getGuild().loadMembers(member -> MemberInfo.concat("\n" + member.getEffectiveName() + " : " + member.getId()));
+                reply(event, MemberInfo);
+            case "channel-info":
+                MessageChannelUnion channel = event.getChannel();
+                String channelInfo = "Channel information\n" +
+                        channel.getName() + " : " +
+                        channel.getId().toString();
+                reply(event, channelInfo);
+
+                break;
+            default:
+                event.reply("I can't handle that command right now :(").setEphemeral(true).queue();
+
+        }
+
+
+    }
+    private void reply(SlashCommandInteractionEvent event, String content){
+        event.reply(content).queue();
+    }
+}
+

--- a/src/main/java/space/space_spring/domain/discord/adapter/in/discord/TestTextCommandEventListener.java
+++ b/src/main/java/space/space_spring/domain/discord/adapter/in/discord/TestTextCommandEventListener.java
@@ -1,0 +1,26 @@
+package space.space_spring.domain.discord.adapter.in.discord;
+
+import jakarta.validation.constraints.NotNull;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestTextCommandEventListener extends ListenerAdapter {
+    @Override
+    public void onMessageReceived(@NotNull MessageReceivedEvent event){
+
+        Message msg = event.getMessage();
+        if(msg.getAuthor().isBot()){
+            return;
+        }
+
+        if(msg.getContentRaw().equals("!ping")){
+            msg.reply("pong").queue();
+            return;
+        }
+    }
+
+
+}

--- a/src/main/java/space/space_spring/global/config/JDA/JDAConfig.java
+++ b/src/main/java/space/space_spring/global/config/JDA/JDAConfig.java
@@ -1,0 +1,47 @@
+package space.space_spring.global.config.JDA;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.requests.GatewayIntent;
+import net.dv8tion.jda.api.utils.ChunkingFilter;
+import net.dv8tion.jda.api.utils.MemberCachePolicy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class JDAConfig {
+
+    @Value("${discord.bot-token}")
+    private String token;  // application.properties에서 토큰 관리
+
+    @Autowired
+    private List<ListenerAdapter> eventListeners; // 모든 리스너 자동 주입
+
+    @Bean
+    public JDA jda() throws InterruptedException {
+        JDABuilder builder = JDABuilder.createDefault(token,
+                GatewayIntent.GUILD_MESSAGES,
+                GatewayIntent.DIRECT_MESSAGES,
+                GatewayIntent.MESSAGE_CONTENT,
+                GatewayIntent.GUILD_MEMBERS);
+
+        // 등록된 모든 이벤트 리스너 추가
+        if(eventListeners.isEmpty()){
+            System.out.println("event listener is empty");
+        }
+        for (ListenerAdapter listener : eventListeners) {
+            builder.addEventListeners(listener);
+        }
+        builder.setActivity(Activity.playing("개굴 봇입니다(spring version)"))
+                .setChunkingFilter(ChunkingFilter.ALL)
+                .setMemberCachePolicy(MemberCachePolicy.ALL);
+
+        return builder.build().awaitReady();
+    }
+}

--- a/src/main/java/space/space_spring/global/config/JDA/SlashCommandRegistrar.java
+++ b/src/main/java/space/space_spring/global/config/JDA/SlashCommandRegistrar.java
@@ -1,0 +1,36 @@
+package space.space_spring.global.config.JDA;
+
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
+import org.springframework.stereotype.Component;
+
+import static net.dv8tion.jda.api.interactions.commands.OptionType.STRING;
+
+@Component
+@RequiredArgsConstructor
+public class SlashCommandRegistrar {
+    private final JDA jda;
+
+    private void registerCommand(){
+        CommandListUpdateAction commands = jda.updateCommands();
+
+        commands.addCommands(
+                Commands.slash("guildinfo","print Guild information.")
+                        .addOption(STRING,"test-option","test-option",false)
+                //.setGuildOnly(true) // this doesn't make sense in DMs
+                //.setDefaultPermissions(DefaultMemberPermissions.DISABLED)
+        );
+        commands.addCommands(
+                Commands.slash("member-info","Get Guild Members info")
+        );
+
+        commands.addCommands(
+                Commands.slash("channel-info","get this Channel info")
+        );
+
+        commands.queue();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,9 +2,9 @@ spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}
     group:
-      "local": "localRDB, localMongoDB, livekit,localS3, localOAuth, localJPA, localPort, localSecret, web-mvc"
-      "dev": "devRDB, devMongoDB, livekit,devS3,devPort, devJPA, devSecret, web-mvc"
-      "prod": "devRDB, devMongoDB, livekit,devS3,devPort, prodJPA, devSecret, web-mvc"
+      "local": "localRDB, localMongoDB, livekit,localS3, localOAuth, localJPA, localPort, localSecret, web-mvc,localDiscordBot"
+      "dev": "devRDB, devMongoDB, livekit,devS3,devPort, devJPA, devSecret, web-mvc, devDiscordBot"
+      "prod": "devRDB, devMongoDB, livekit,devS3,devPort, prodJPA, devSecret, web-mvc, devDiscordBot"
 ---
 spring:
   config:
@@ -128,3 +128,12 @@ spring:
     multipart:
       max-file-size: 5MB
       max-request-size: 5MB
+
+---
+spring:
+  config:
+    activate:
+      on-profile: "devDiscordBot"
+
+discord:
+  bot-token: ${DISCORD_BOT_TOKEN}


### PR DESCRIPTION
## 📝 요약

이슈 번호 : #185 

JDA를 spring 에서 사용할 수 있도록 시험 코드를 짜봤습니다.

## 🔖 변경 사항
JDA config : JDA 핵심 인스턴트 생성. 앞으로 다른 discord 관련 클래스들은 이 jda를 주입 받아 사용하게 됩니다.
discord.adapter.in.discord.~~EventListener : 디스코드 이벤트를 감지하는 클래스 입니다. inputController 처럼 사용합니다.

## ✅ 리뷰 요구사항
파일 구조에 대한 의견이 듣고 싶습니다.
그리고 디스코드가 다른 도메인들과 관련이 많은 만큼, 앞으로 어떤 디렉토리 구조가 좋을지 의견 듣고 싶습니다.
현재는 이 PR에서 처럼 Domian.discord안에 전부 넣을 생각입니다.

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
