### PR TITLE
[Feat] create space flow

### DIFF
--- a/src/main/java/space/space_spring/domain/discord/adapter/in/discord/TestTextCommandEventListener.java
+++ b/src/main/java/space/space_spring/domain/discord/adapter/in/discord/TestTextCommandEventListener.java
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.springframework.stereotype.Component;
 import space.space_spring.domain.space.application.port.in.CreateSpaceCommand;
 import space.space_spring.domain.space.application.port.in.CreateSpaceUseCase;
+import space.space_spring.global.exception.CustomException;
 
 @Component
 @RequiredArgsConstructor
@@ -35,16 +36,19 @@ public class TestTextCommandEventListener extends ListenerAdapter {
                     .guildName(guild.getName())
                     .build();
 
-            Long spaceId = createSpaceUseCase.createSpace(command);
-            if(spaceId==null){
-                /*
-                 * 이미 guild가 space로 등록이 된 경우
-                 * */
-                event.getMessage().reply("this guild already initiated\nspace ID : "+spaceId+"\n").queue();
+            try{Long spaceId = createSpaceUseCase.createSpace(command);
+                event.getMessage()
+                        .reply("space setting success!\nspace ID : "+spaceId+"\n").queue();
+            }
+            catch (CustomException e){
+            /*
+             * 이미 guild가 space로 등록이 된 경우
+             * */
+                event.getMessage().reply(e.getMessage()).queue();
                 return;
             }
-            event.getMessage()
-                    .reply("space setting success!\nspace ID : "+spaceId+"\n").queue();
+
+
                     ;
         }
     }

--- a/src/main/java/space/space_spring/domain/discord/adapter/in/discord/TestTextCommandEventListener.java
+++ b/src/main/java/space/space_spring/domain/discord/adapter/in/discord/TestTextCommandEventListener.java
@@ -1,13 +1,20 @@
 package space.space_spring.domain.discord.adapter.in.discord;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.springframework.stereotype.Component;
+import space.space_spring.domain.space.application.port.in.CreateSpaceCommand;
+import space.space_spring.domain.space.application.port.in.CreateSpaceUseCase;
 
 @Component
+@RequiredArgsConstructor
 public class TestTextCommandEventListener extends ListenerAdapter {
+
+    private final CreateSpaceUseCase createSpaceUseCase;
     @Override
     public void onMessageReceived(@NotNull MessageReceivedEvent event){
 
@@ -19,6 +26,26 @@ public class TestTextCommandEventListener extends ListenerAdapter {
         if(msg.getContentRaw().equals("!ping")){
             msg.reply("pong").queue();
             return;
+        }
+        if(msg.getContentRaw().equals("!init-space")){
+            //이 길드를 space로 등록합니다
+            Guild guild = event.getGuild();
+            CreateSpaceCommand command = CreateSpaceCommand.builder()
+                    .guildId(guild.getIdLong())
+                    .guildName(guild.getName())
+                    .build();
+
+            Long spaceId = createSpaceUseCase.createSpace(command);
+            if(spaceId==null){
+                /*
+                 * 이미 guild가 space로 등록이 된 경우
+                 * */
+                event.getMessage().reply("this guild already initiated\nspace ID : "+spaceId+"\n").queue();
+                return;
+            }
+            event.getMessage()
+                    .reply("space setting success!\nspace ID : "+spaceId+"\n").queue();
+                    ;
         }
     }
 

--- a/src/main/java/space/space_spring/domain/space/SpaceMapper.java
+++ b/src/main/java/space/space_spring/domain/space/SpaceMapper.java
@@ -1,7 +1,8 @@
 package space.space_spring.domain.space;
 
-import lombok.Getter;
 import org.springframework.stereotype.Component;
+import space.space_spring.domain.space.domain.Space;
+import space.space_spring.domain.space.domain.SpaceJpaEntity;
 
 @Component
 public class SpaceMapper {

--- a/src/main/java/space/space_spring/domain/space/adapter/in/discord/CreateSpaceEventListener.java
+++ b/src/main/java/space/space_spring/domain/space/adapter/in/discord/CreateSpaceEventListener.java
@@ -1,0 +1,50 @@
+package space.space_spring.domain.space.adapter.in.discord;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.springframework.stereotype.Component;
+import space.space_spring.domain.space.application.port.in.CreateSpaceCommand;
+import space.space_spring.domain.space.application.port.in.CreateSpaceUseCase;
+
+@Component
+@RequiredArgsConstructor
+public class CreateSpaceEventListener extends ListenerAdapter {
+    private final CreateSpaceUseCase createSpaceUseCase;
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        // Only accept commands from guilds
+        if (event.getGuild() == null)
+            return;
+        if(event.getName().equals("init-space")){
+            //이 길드를 space로 등록합니다
+            Guild guild = event.getGuild();
+            CreateSpaceCommand command = CreateSpaceCommand.builder()
+                    .guildId(guild.getIdLong())
+                    .guildName(guild.getName())
+                    .build();
+
+            Long spaceId = createSpaceUseCase.createSpace(command);
+            if(spaceId==null){
+                /*
+                * 이미 guild가 space로 등록이 된 경우
+                * */
+                event.getInteraction()
+                        .reply("this guild already initiated\nspace ID : "+spaceId+"\n")
+                        .setEphemeral(true)
+                        .queue();
+                return;
+            }
+            event.getInteraction()
+                    .reply("space setting success!\nspace ID : "+spaceId+"\n")
+                    .setEphemeral(true)
+                    .queue();
+
+
+            return;
+        }
+    }
+}

--- a/src/main/java/space/space_spring/domain/space/adapter/out/persistence/SpacePersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/space/adapter/out/persistence/SpacePersistenceAdapter.java
@@ -8,6 +8,11 @@ import space.space_spring.domain.space.application.port.out.CreateSpacePort;
 import space.space_spring.domain.space.application.port.out.LoadSpacePort;
 import space.space_spring.domain.space.domain.Space;
 import space.space_spring.domain.space.domain.SpaceJpaEntity;
+import space.space_spring.global.exception.CustomException;
+
+import java.util.Optional;
+
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.SPACE_ALREADY_EXISTED;
 
 @RequiredArgsConstructor
 @Repository
@@ -24,12 +29,12 @@ public class SpacePersistenceAdapter implements CreateSpacePort , LoadSpacePort 
     }
 
     @Override
-    public Space loadSpaceByDiscordId(Long discordId){
-        SpaceJpaEntity spaceJpaEntity = spaceRepository.findByDiscordId(discordId);
-        if(spaceJpaEntity==null){
-            return null;
-        }
-        return spaceMapper.mapToDomainEntity(spaceJpaEntity);
+    public Optional<Space> loadSpaceByDiscordId(Long discordId){
+        //없으면 Optional.empty() 반환
+        return spaceRepository.findByDiscordId(discordId)
+                .map(spaceMapper::mapToDomainEntity);
+
+
     }
 
 }

--- a/src/main/java/space/space_spring/domain/space/adapter/out/persistence/SpacePersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/space/adapter/out/persistence/SpacePersistenceAdapter.java
@@ -24,8 +24,8 @@ public class SpacePersistenceAdapter implements CreateSpacePort , LoadSpacePort 
 
         Space space = Space.withoutId(guildId,guildName);
         SpaceJpaEntity spaceJpaEntity = spaceMapper.mapToJpaEntity(space);
-        SpaceJpaEntity resultSpaceJpaEntity = spaceRepository.save(spaceJpaEntity);
-        return resultSpaceJpaEntity.getId();
+        Long spaceId = spaceRepository.save(spaceJpaEntity).getId();
+        return spaceId;
     }
 
     @Override

--- a/src/main/java/space/space_spring/domain/space/adapter/out/persistence/SpacePersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/space/adapter/out/persistence/SpacePersistenceAdapter.java
@@ -1,0 +1,35 @@
+package space.space_spring.domain.space.adapter.out.persistence;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import space.space_spring.domain.pay.application.port.out.CreatePayPort;
+import space.space_spring.domain.space.SpaceMapper;
+import space.space_spring.domain.space.application.port.out.CreateSpacePort;
+import space.space_spring.domain.space.application.port.out.LoadSpacePort;
+import space.space_spring.domain.space.domain.Space;
+import space.space_spring.domain.space.domain.SpaceJpaEntity;
+
+@RequiredArgsConstructor
+@Repository
+public class SpacePersistenceAdapter implements CreateSpacePort , LoadSpacePort {
+    private final SpringDataSpace spaceRepository;
+    private final SpaceMapper spaceMapper;
+    @Override
+    public Long saveSpace(Long guildId,String guildName){
+
+        Space space = Space.withoutId(guildId,guildName);
+        SpaceJpaEntity spaceJpaEntity = spaceMapper.mapToJpaEntity(space);
+        SpaceJpaEntity resultSpaceJpaEntity = spaceRepository.save(spaceJpaEntity);
+        return resultSpaceJpaEntity.getId();
+    }
+
+    @Override
+    public Space loadSpaceByDiscordId(Long discordId){
+        SpaceJpaEntity spaceJpaEntity = spaceRepository.findByDiscordId(discordId);
+        if(spaceJpaEntity==null){
+            return null;
+        }
+        return spaceMapper.mapToDomainEntity(spaceJpaEntity);
+    }
+
+}

--- a/src/main/java/space/space_spring/domain/space/adapter/out/persistence/SpringDataSpace.java
+++ b/src/main/java/space/space_spring/domain/space/adapter/out/persistence/SpringDataSpace.java
@@ -4,6 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import space.space_spring.domain.pay.adapter.out.persistence.PayRequestTargetJpaEntity;
 import space.space_spring.domain.space.domain.SpaceJpaEntity;
 
+import java.util.Optional;
+
 public interface SpringDataSpace extends JpaRepository<SpaceJpaEntity, Long> {
-    SpaceJpaEntity findByDiscordId(Long discordId);
+    Optional<SpaceJpaEntity> findByDiscordId(Long discordId);
 }

--- a/src/main/java/space/space_spring/domain/space/adapter/out/persistence/SpringDataSpace.java
+++ b/src/main/java/space/space_spring/domain/space/adapter/out/persistence/SpringDataSpace.java
@@ -1,0 +1,9 @@
+package space.space_spring.domain.space.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import space.space_spring.domain.pay.adapter.out.persistence.PayRequestTargetJpaEntity;
+import space.space_spring.domain.space.domain.SpaceJpaEntity;
+
+public interface SpringDataSpace extends JpaRepository<SpaceJpaEntity, Long> {
+    SpaceJpaEntity findByDiscordId(Long discordId);
+}

--- a/src/main/java/space/space_spring/domain/space/application/port/in/CreateSpaceCommand.java
+++ b/src/main/java/space/space_spring/domain/space/application/port/in/CreateSpaceCommand.java
@@ -1,0 +1,26 @@
+package space.space_spring.domain.space.application.port.in;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+
+public class CreateSpaceCommand {
+
+    private Long guildId;
+
+    //limit 100 char
+    private String guildName;
+
+    @Builder
+    private CreateSpaceCommand(Long guildId,String guildName){
+        this.guildId=guildId;
+        this.guildName = guildName;
+    }
+    static public CreateSpaceCommand of(Long guildId,String guildName){
+           return CreateSpaceCommand.builder()
+                   .guildName(guildName)
+                   .guildId(guildId)
+                   .build();
+    }
+}

--- a/src/main/java/space/space_spring/domain/space/application/port/in/CreateSpaceUseCase.java
+++ b/src/main/java/space/space_spring/domain/space/application/port/in/CreateSpaceUseCase.java
@@ -1,0 +1,5 @@
+package space.space_spring.domain.space.application.port.in;
+
+public interface CreateSpaceUseCase {
+    Long createSpace(CreateSpaceCommand command);
+}

--- a/src/main/java/space/space_spring/domain/space/application/port/out/CreateSpacePort.java
+++ b/src/main/java/space/space_spring/domain/space/application/port/out/CreateSpacePort.java
@@ -1,0 +1,6 @@
+package space.space_spring.domain.space.application.port.out;
+
+public interface CreateSpacePort {
+
+    Long saveSpace(Long discordGuildId,String spaceName);
+}

--- a/src/main/java/space/space_spring/domain/space/application/port/out/LoadSpacePort.java
+++ b/src/main/java/space/space_spring/domain/space/application/port/out/LoadSpacePort.java
@@ -2,6 +2,8 @@ package space.space_spring.domain.space.application.port.out;
 
 import space.space_spring.domain.space.domain.Space;
 
+import java.util.Optional;
+
 public interface LoadSpacePort {
-    Space loadSpaceByDiscordId(Long discordId);
+    Optional<Space> loadSpaceByDiscordId(Long discordId);
 }

--- a/src/main/java/space/space_spring/domain/space/application/port/out/LoadSpacePort.java
+++ b/src/main/java/space/space_spring/domain/space/application/port/out/LoadSpacePort.java
@@ -1,0 +1,7 @@
+package space.space_spring.domain.space.application.port.out;
+
+import space.space_spring.domain.space.domain.Space;
+
+public interface LoadSpacePort {
+    Space loadSpaceByDiscordId(Long discordId);
+}

--- a/src/main/java/space/space_spring/domain/space/application/service/CreateSpaceService.java
+++ b/src/main/java/space/space_spring/domain/space/application/service/CreateSpaceService.java
@@ -9,6 +9,11 @@ import space.space_spring.domain.space.application.port.in.CreateSpaceUseCase;
 import space.space_spring.domain.space.application.port.out.CreateSpacePort;
 import space.space_spring.domain.space.application.port.out.LoadSpacePort;
 import space.space_spring.domain.space.domain.Space;
+import space.space_spring.global.exception.CustomException;
+
+import java.util.Optional;
+
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.SPACE_ALREADY_EXISTED;
 
 @Service
 @RequiredArgsConstructor
@@ -20,11 +25,16 @@ public class CreateSpaceService implements CreateSpaceUseCase {
     @Override
     @Transactional
     public Long createSpace(CreateSpaceCommand command){
-        Space space=loadSpacePort.loadSpaceByDiscordId(command.getGuildId());
-        if(space!=null){
-            return null;
-        }
+
+        checkSpacePresent(loadSpacePort.loadSpaceByDiscordId(command.getGuildId()));
         return createSpacePort.saveSpace(command.getGuildId(),
                 command.getGuildName());
+    }
+
+    private void checkSpacePresent(Optional<Space> space){
+        space.ifPresent(value->{
+            throw  new CustomException(SPACE_ALREADY_EXISTED,
+                    SPACE_ALREADY_EXISTED.getMessage()+"\nspaceId: "+value.getId());
+        });
     }
 }

--- a/src/main/java/space/space_spring/domain/space/application/service/CreateSpaceService.java
+++ b/src/main/java/space/space_spring/domain/space/application/service/CreateSpaceService.java
@@ -1,0 +1,30 @@
+package space.space_spring.domain.space.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import space.space_spring.domain.space.adapter.out.persistence.SpacePersistenceAdapter;
+import space.space_spring.domain.space.application.port.in.CreateSpaceCommand;
+import space.space_spring.domain.space.application.port.in.CreateSpaceUseCase;
+import space.space_spring.domain.space.application.port.out.CreateSpacePort;
+import space.space_spring.domain.space.application.port.out.LoadSpacePort;
+import space.space_spring.domain.space.domain.Space;
+
+@Service
+@RequiredArgsConstructor
+@Transactional()
+public class CreateSpaceService implements CreateSpaceUseCase {
+
+    private final CreateSpacePort createSpacePort;
+    private final LoadSpacePort loadSpacePort;
+    @Override
+    @Transactional
+    public Long createSpace(CreateSpaceCommand command){
+        Space space=loadSpacePort.loadSpaceByDiscordId(command.getGuildId());
+        if(space!=null){
+            return null;
+        }
+        return createSpacePort.saveSpace(command.getGuildId(),
+                command.getGuildName());
+    }
+}

--- a/src/main/java/space/space_spring/domain/space/domain/Space.java
+++ b/src/main/java/space/space_spring/domain/space/domain/Space.java
@@ -22,6 +22,6 @@ public class Space {
     }
 
     public static Space withoutId(Long discordId, String name){
-        return Space.create(null,name,discordId);
+        return new Space(null, name, discordId);
     }
 }

--- a/src/main/java/space/space_spring/domain/space/domain/Space.java
+++ b/src/main/java/space/space_spring/domain/space/domain/Space.java
@@ -1,4 +1,4 @@
-package space.space_spring.domain.space;
+package space.space_spring.domain.space.domain;
 
 import lombok.Getter;
 
@@ -19,5 +19,9 @@ public class Space {
 
     public static Space create(Long id, String name, Long discordId) {
         return new Space(id, name, discordId);
+    }
+
+    public static Space withoutId(Long discordId, String name){
+        return Space.create(null,name,discordId);
     }
 }

--- a/src/main/java/space/space_spring/domain/space/domain/SpaceJpaEntity.java
+++ b/src/main/java/space/space_spring/domain/space/domain/SpaceJpaEntity.java
@@ -1,4 +1,4 @@
-package space.space_spring.domain.space;
+package space.space_spring.domain.space.domain;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/space/space_spring/domain/spaceMember/SpaceMember.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/SpaceMember.java
@@ -1,7 +1,7 @@
 package space.space_spring.domain.spaceMember;
 
 import lombok.Getter;
-import space.space_spring.domain.space.Space;
+import space.space_spring.domain.space.domain.Space;
 import space.space_spring.domain.user.User;
 
 @Getter

--- a/src/main/java/space/space_spring/domain/spaceMember/SpaceMemberJpaEntity.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/SpaceMemberJpaEntity.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import space.space_spring.domain.space.SpaceJpaEntity;
+import space.space_spring.domain.space.domain.SpaceJpaEntity;
 import space.space_spring.domain.user.UserJpaEntity;
 import space.space_spring.global.common.entity.BaseEntity;
 

--- a/src/main/java/space/space_spring/domain/spaceMember/SpaceMemberMapper.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/SpaceMemberMapper.java
@@ -1,7 +1,7 @@
 package space.space_spring.domain.spaceMember;
 
 import org.springframework.stereotype.Component;
-import space.space_spring.domain.space.Space;
+import space.space_spring.domain.space.domain.Space;
 import space.space_spring.domain.user.User;
 
 @Component

--- a/src/main/java/space/space_spring/domain/spaceMember/SpaceMemberPersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/SpaceMemberPersistenceAdapter.java
@@ -3,7 +3,7 @@ package space.space_spring.domain.spaceMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import space.space_spring.domain.pay.application.port.out.LoadSpaceMemberPort;
-import space.space_spring.domain.space.Space;
+import space.space_spring.domain.space.domain.Space;
 import space.space_spring.domain.space.SpaceMapper;
 import space.space_spring.domain.user.User;
 import space.space_spring.domain.user.UserMapper;

--- a/src/main/java/space/space_spring/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/global/common/response/status/BaseExceptionResponseStatus.java
@@ -67,6 +67,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     nff(6004, HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     gnf(6005, HttpStatus.BAD_REQUEST, "잘못된 회원 status 값입니다."),
     fb(6006, HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다."),
+    SPACE_ALREADY_EXISTED(6007,HttpStatus.BAD_REQUEST,"이미 등록된 SPACE입니다"),
 
     /**
      * 7000: SpaceMember 오류

--- a/src/main/java/space/space_spring/global/config/JDA/SlashCommandRegistrar.java
+++ b/src/main/java/space/space_spring/global/config/JDA/SlashCommandRegistrar.java
@@ -3,18 +3,26 @@ package space.space_spring.global.config.JDA;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import static net.dv8tion.jda.api.interactions.commands.OptionType.STRING;
 
 @Component
-@RequiredArgsConstructor
+
 public class SlashCommandRegistrar {
     private final JDA jda;
 
-    private void registerCommand(){
+    @Autowired
+    public SlashCommandRegistrar(JDA jda) {
+        this.jda = jda;
+        this.registerCommands();
+    }
+    private void registerCommands(){
         CommandListUpdateAction commands = jda.updateCommands();
 
         commands.addCommands(
@@ -33,6 +41,15 @@ public class SlashCommandRegistrar {
         commands.addCommands(
                 Commands.slash("channel-info","get this Channel info")
         );
+
+        commands.addCommands(
+                Commands.slash("set-board","get this Channel info")
+                        .addOptions(
+                                new OptionData(OptionType.STRING, "board-type", "게시판 종류를 선택해주세요")
+                                .addChoice("Board", "일반 게시판입니다. 익명 기능이 없습니다")
+                                .addChoice("question-Board", "질문 게시판입니다. 익명 기능이 있습니다.")
+
+        ));
 
         commands.queue();
     }

--- a/src/main/java/space/space_spring/global/config/JDA/SlashCommandRegistrar.java
+++ b/src/main/java/space/space_spring/global/config/JDA/SlashCommandRegistrar.java
@@ -18,6 +18,9 @@ public class SlashCommandRegistrar {
         CommandListUpdateAction commands = jda.updateCommands();
 
         commands.addCommands(
+                Commands.slash("init-space","initiate this Guild to Space. first call this command when add Space Bot")
+        );
+        commands.addCommands(
                 Commands.slash("guildinfo","print Guild information.")
                         .addOption(STRING,"test-option","test-option",false)
                 //.setGuildOnly(true) // this doesn't make sense in DMs

--- a/src/test/java/space/space_spring/domain/pay/application/service/CreatePayServiceTest.java
+++ b/src/test/java/space/space_spring/domain/pay/application/service/CreatePayServiceTest.java
@@ -8,7 +8,7 @@ import space.space_spring.domain.pay.adapter.in.web.TargetOfPayRequest;
 import space.space_spring.domain.pay.application.port.in.CreatePayCommand;
 import space.space_spring.domain.pay.application.port.out.CreatePayPort;
 import space.space_spring.domain.pay.application.port.out.LoadSpaceMemberPort;
-import space.space_spring.domain.space.Space;
+import space.space_spring.domain.space.domain.Space;
 import space.space_spring.domain.spaceMember.SpaceMember;
 import space.space_spring.domain.user.User;
 import space.space_spring.global.exception.CustomException;


### PR DESCRIPTION

## 📝 요약
discord guild를 space로 생성하는 flow

- #190 

1. discord slash command 혹은 text command(임시)를 사용해 길드 등록(`init-space`)
2. 해당 길드를 space로 생성
3. 생성된 space id를 반환

## 🔖 변경 사항
domian.space에 클린 아키텍쳐 적용하여 필요한 adapter, application, domain을 추가 하였습니다.


## ✅ 리뷰 요구사항
pay domain을 따라서 구현 해보았습니다. 
아키텍쳐 관련, 코드 관련 피드백 부탁드립니다.

추가적으로 "이미 등록된 space 확인"하는 flow가 현재 `CreateSpaceUsecase`가 `null`을 반환하는 것으로 판단됩니다.
더 좋은 코드 추천 부탁드립니다.
(따로 `checkUsecase`를 만들지 않고, controller에서 adapter를 호출하는 것을 피하기 위해서 이렇게 설계 했습니다) 



<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
