### PR TITLE
Feat/#240: Swagger 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis';
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }
 
 test {

--- a/src/main/java/space/space_spring/domain/event/adapter/in/web/createEvent/CreateEventController.java
+++ b/src/main/java/space/space_spring/domain/event/adapter/in/web/createEvent/CreateEventController.java
@@ -2,6 +2,8 @@ package space.space_spring.domain.event.adapter.in.web.createEvent;
 
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.*;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
@@ -16,10 +18,16 @@ import space.space_spring.global.exception.CustomException;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Event", description = "행사 관련 API")
 public class CreateEventController {
 
     private final CreateEventUseCase createEventUseCase;
 
+    @Operation(summary = "행사 생성", description = """
+        
+        관리자가 새로운 행사를 생성합니다.
+        
+        """)
     @PostMapping("/event")
     public BaseResponse<CreateEventResponse> createEvent(@JwtLoginAuth Long id, @Validated @RequestBody CreateEventRequest request, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {

--- a/src/main/java/space/space_spring/domain/event/adapter/in/web/joinEvent/JoinEventController.java
+++ b/src/main/java/space/space_spring/domain/event/adapter/in/web/joinEvent/JoinEventController.java
@@ -1,5 +1,7 @@
 package space.space_spring.domain.event.adapter.in.web.joinEvent;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,10 +13,16 @@ import space.space_spring.global.common.response.SuccessResponse;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Event", description = "행사 관련 API")
 public class JoinEventController {
 
     private final JoinEventUseCase joinEventUseCase;
 
+    @Operation(summary = "행사 참여", description = """
+        
+        행사 id로 해당 행사에 참여합니다.
+        
+        """)
     @PostMapping("/event/{eventId}/join")
     public BaseResponse<SuccessResponse> joinEvent(@JwtLoginAuth Long id, @PathVariable Long eventId) {
         boolean isJoinSuccess = joinEventUseCase.joinEvent(id, eventId);

--- a/src/main/java/space/space_spring/domain/event/adapter/in/web/readEvent/ReadEventController.java
+++ b/src/main/java/space/space_spring/domain/event/adapter/in/web/readEvent/ReadEventController.java
@@ -1,5 +1,7 @@
 package space.space_spring.domain.event.adapter.in.web.readEvent;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,17 +16,28 @@ import space.space_spring.global.common.response.BaseResponse;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Event", description = "행사 관련 API")
 public class ReadEventController {
 
     private final ReadEventUseCase readEventUseCase;
     private final ReadEventParticipantUseCase readEventParticipantUseCase;
 
+    @Operation(summary = "행사 전체 조회", description = """
+        
+        관리자가 해당 스페이스에서 생성된 모든 행사를 조회합니다.
+        
+        """)
     @GetMapping("/events")
     public BaseResponse<ReadEventsResponse> readEvents(@JwtLoginAuth Long id) {
         Events events = readEventUseCase.readEvents(id);
         return new BaseResponse<>(ReadEventsResponse.create(events));
     }
 
+    @Operation(summary = "행사 단건 조회", description = """
+        
+        관리자가 특정 행사에 대한 세부 정보를 조회합니다.
+        
+        """)
     @GetMapping("/event/{eventId}")
     public BaseResponse<ReadEventInfoResponse> readEvent(@JwtLoginAuth Long id, @PathVariable Long eventId) {
         Event event = readEventUseCase.readEvent(eventId);

--- a/src/main/java/space/space_spring/global/config/SwaggerConfig.java
+++ b/src/main/java/space/space_spring/global/config/SwaggerConfig.java
@@ -1,0 +1,50 @@
+package space.space_spring.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import org.springdoc.core.utils.SpringDocUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import space.space_spring.global.argumentResolver.jwtLogin.JwtLoginAuth;
+
+@OpenAPIDefinition(
+        servers = {
+                @Server(url = "/"),
+        }
+)
+@Configuration
+public class SwaggerConfig {
+
+    static {
+        SpringDocUtils.getConfig().addAnnotationsToIgnore(JwtLoginAuth.class);
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        String jwtSchemeName = "Authorization";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        Components components = new Components().addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT"));
+
+
+        Info info = new Info()
+                .version("v2.0")
+                .title("Space API")
+                .description("동아리 통합 관리 서비스 [Space] API");
+
+        return new OpenAPI()
+                .components(components)
+                .info(info)
+                .addSecurityItem(securityRequirement);
+
+    }
+}

--- a/src/main/java/space/space_spring/global/config/interceptorURL/JwtLoginInterceptorURL.java
+++ b/src/main/java/space/space_spring/global/config/interceptorURL/JwtLoginInterceptorURL.java
@@ -6,9 +6,7 @@ import lombok.Getter;
 public enum JwtLoginInterceptorURL {
     SPACE("/space/**"),
     TEST("/test/**"),
-    SPACE_LIST_FOR_USER("/user/space-choice"),
-    VOICE_ROOM("/voiceRoom/**"),
-    USER_PROFILE_LIST("/user/profile");
+    ;
 
     private final String urlPattern;
 


### PR DESCRIPTION
## 📝 요약
- resolved #240 

## 🔖 변경 사항
- swagger 의존성 추가 (v2.6.0)
- Event 도메인에 swagger 적용

## ✅ 리뷰 요구사항


## 📸 확인 방법 (선택)
**`{서버주소}/swagger-ui/index.html`** 경로로 접속하시면 됩니다. (로컬에서 확인하려면 localhost:8080/swagger-ui/index.html)
- 꼭 오른쪽 상단 `Authorize`로 토큰 입력한 후에 요청 보내야 합니다!
  근데 지금은 토큰 임의로 발급받기도 까다롭고, `JwtInerceptorURL`에 등록돼있는 `/space` 패턴의 API가 없어서.. 전 임의로 url 추가 + 만료된 토큰으로 테스트해봤습니다.
<img width="1710" alt="스크린샷 2025-02-26 00 02 44" src="https://github.com/user-attachments/assets/ae240a33-c379-4885-a603-c374a3c77ab6" />

- `Authorize` 후 요청 보낸 결과 
<img width="1710" alt="스크린샷 2025-02-26 00 01 54" src="https://github.com/user-attachments/assets/d88d9021-cc50-4353-9d75-e433dcbe4cb5" />


<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
