### PR TITLE
Feat/#238: jwt 토큰 페이로드 수정

### DIFF
--- a/src/main/java/space/space_spring/domain/authorization/jwt/model/JwtLoginProvider.java
+++ b/src/main/java/space/space_spring/domain/authorization/jwt/model/JwtLoginProvider.java
@@ -32,16 +32,16 @@ public class JwtLoginProvider {
     @Value("${secret.jwt.refresh-expired-in}")
     private Long REFRESH_EXPIRED_IN;
 
-    public String generateToken(Long spaceMemberId, TokenType tokenType) {
+    public String generateToken(Long userId, Long spaceMemberId, TokenType tokenType) {
 //        Claims claims = Jwts.claims().setSubject(jwtPayloadDto.getUserId().toString());
 
         Date now = new Date();
         Date expiration = setExpiration(now, tokenType);
 
-        return makeToken(tokenType, spaceMemberId, now, expiration);
+        return makeToken(tokenType, userId, spaceMemberId, now, expiration);
     }
 
-    private String makeToken(TokenType tokenType, Long spaceMemberId, Date now, Date expiration) {
+    private String makeToken(TokenType tokenType, Long userId, Long spaceMemberId, Date now, Date expiration) {
         if (tokenType.equals(TokenType.ACCESS)) {
             return Jwts.builder()
 //                .setClaims(claims)
@@ -56,6 +56,7 @@ public class JwtLoginProvider {
 //                .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(expiration)
+                .claim("userId", userId)
                 .signWith(SignatureAlgorithm.HS256, choiceSecretKey(tokenType))
                 .compact();
     }

--- a/src/main/java/space/space_spring/domain/user/adapter/out/persistence/RefreshTokenRepository.java
+++ b/src/main/java/space/space_spring/domain/user/adapter/out/persistence/RefreshTokenRepository.java
@@ -12,17 +12,18 @@ import java.time.Duration;
 public class RefreshTokenRepository {
 
     private final StringRedisTemplate redisTemplate;
-    private static final String PREFIX = "refreshToken:";
+    private static final String REFRESH_TOKEN_KEY = "refreshToken";
 
     public void save(Long userId, String refreshToken) {
-        redisTemplate.opsForValue().set(PREFIX + userId, refreshToken, Duration.ofDays(14));
+        redisTemplate.opsForHash().put(REFRESH_TOKEN_KEY, String.valueOf(userId), refreshToken);
+        redisTemplate.expire(REFRESH_TOKEN_KEY, Duration.ofDays(14));
     }
 
     public Optional<String> findByUserId(Long userId) {
-        return Optional.ofNullable(redisTemplate.opsForValue().get(PREFIX + userId));
+        return Optional.ofNullable((String) redisTemplate.opsForHash().get("refreshToken", String.valueOf(userId)));
     }
 
     public boolean deleteByUserId(Long userId) {
-        return Boolean.TRUE.equals(redisTemplate.delete(PREFIX + userId));
+        return redisTemplate.opsForHash().delete(REFRESH_TOKEN_KEY, String.valueOf(userId)) > 0;
     }
 }

--- a/src/main/java/space/space_spring/domain/user/adapter/out/persistence/RefreshTokenRepository.java
+++ b/src/main/java/space/space_spring/domain/user/adapter/out/persistence/RefreshTokenRepository.java
@@ -12,18 +12,17 @@ import java.time.Duration;
 public class RefreshTokenRepository {
 
     private final StringRedisTemplate redisTemplate;
-    private static final String REFRESH_TOKEN_KEY = "refreshToken";
+    private static final String REFRESH_TOKEN_PREFIX = "refreshToken:";
 
     public void save(Long userId, String refreshToken) {
-        redisTemplate.opsForHash().put(REFRESH_TOKEN_KEY, String.valueOf(userId), refreshToken);
-        redisTemplate.expire(REFRESH_TOKEN_KEY, Duration.ofDays(14));
+        redisTemplate.opsForValue().set(REFRESH_TOKEN_PREFIX + userId, refreshToken, Duration.ofDays(7));
     }
 
     public Optional<String> findByUserId(Long userId) {
-        return Optional.ofNullable((String) redisTemplate.opsForHash().get("refreshToken", String.valueOf(userId)));
+        return Optional.ofNullable(redisTemplate.opsForValue().get(REFRESH_TOKEN_PREFIX + userId));
     }
 
     public boolean deleteByUserId(Long userId) {
-        return redisTemplate.opsForHash().delete(REFRESH_TOKEN_KEY, String.valueOf(userId)) > 0;
+        return redisTemplate.opsForHash().delete(REFRESH_TOKEN_PREFIX, String.valueOf(userId)) > 0;
     }
 }

--- a/src/main/java/space/space_spring/domain/user/application/service/DiscordOauthService.java
+++ b/src/main/java/space/space_spring/domain/user/application/service/DiscordOauthService.java
@@ -41,9 +41,9 @@ public class DiscordOauthService implements OauthUseCase {
 
         if (savedUser.isPresent()) {
             Long userId = savedUser.get().getId();
-            Long spaceMemberId = getSpaceMemberId(savedUser.get());
-            String accessToken = jwtLoginProvider.generateToken(userId, spaceMemberId, TokenType.ACCESS);
-            String refreshToken = jwtLoginProvider.generateToken(userId, spaceMemberId, TokenType.REFRESH);
+            SpaceMember spaceMember = getSpaceMember(savedUser.get());
+            String accessToken = jwtLoginProvider.generateAccessToken(spaceMember.getSpaceId(), spaceMember.getId());
+            String refreshToken = jwtLoginProvider.generateRefreshToken(userId);
             createRefreshTokenPort.create(savedUser.get().getId(), refreshToken);
             return new TokenPair(accessToken, refreshToken);
         }
@@ -51,9 +51,8 @@ public class DiscordOauthService implements OauthUseCase {
 
     }
 
-    private Long getSpaceMemberId(User savedUser) {
-        SpaceMember spaceMember = loadSpaceMemberPort.loadByUserId(savedUser.getId());
-        return spaceMember.getSpaceId();
+    private SpaceMember getSpaceMember(User savedUser) {
+        return loadSpaceMemberPort.loadByUserId(savedUser.getId());
     }
 
 }

--- a/src/main/java/space/space_spring/domain/user/application/service/DiscordOauthService.java
+++ b/src/main/java/space/space_spring/domain/user/application/service/DiscordOauthService.java
@@ -40,9 +40,10 @@ public class DiscordOauthService implements OauthUseCase {
         Optional<User> savedUser = loadUserPort.loadUserByDiscordId(user.getDiscordId());
 
         if (savedUser.isPresent()) {
+            Long userId = savedUser.get().getId();
             Long spaceMemberId = getSpaceMemberId(savedUser.get());
-            String accessToken = jwtLoginProvider.generateToken(spaceMemberId, TokenType.ACCESS);
-            String refreshToken = jwtLoginProvider.generateToken(spaceMemberId, TokenType.REFRESH);
+            String accessToken = jwtLoginProvider.generateToken(userId, spaceMemberId, TokenType.ACCESS);
+            String refreshToken = jwtLoginProvider.generateToken(userId, spaceMemberId, TokenType.REFRESH);
             createRefreshTokenPort.create(savedUser.get().getId(), refreshToken);
             return new TokenPair(accessToken, refreshToken);
         }

--- a/src/main/java/space/space_spring/domain/user/application/service/TokenService.java
+++ b/src/main/java/space/space_spring/domain/user/application/service/TokenService.java
@@ -64,8 +64,8 @@ public class TokenService implements TokenUseCase {
     }
 
     private TokenPair updateTokenPair(SpaceMember spaceMember) {
-        String newAccessToken = jwtLoginProvider.generateToken(spaceMember.getId(), TokenType.ACCESS);
-        String newRefreshToken = jwtLoginProvider.generateToken(spaceMember.getId(), TokenType.REFRESH);
+        String newAccessToken = jwtLoginProvider.generateToken(spaceMember.getUserId(), spaceMember.getId(), TokenType.ACCESS);
+        String newRefreshToken = jwtLoginProvider.generateToken(spaceMember.getUserId(), spaceMember.getId(), TokenType.REFRESH);
 
         createRefreshTokenPort.create(spaceMember.getUserId(), newRefreshToken);
 

--- a/src/main/java/space/space_spring/domain/user/application/service/TokenService.java
+++ b/src/main/java/space/space_spring/domain/user/application/service/TokenService.java
@@ -64,8 +64,8 @@ public class TokenService implements TokenUseCase {
     }
 
     private TokenPair updateTokenPair(SpaceMember spaceMember) {
-        String newAccessToken = jwtLoginProvider.generateToken(spaceMember.getUserId(), spaceMember.getId(), TokenType.ACCESS);
-        String newRefreshToken = jwtLoginProvider.generateToken(spaceMember.getUserId(), spaceMember.getId(), TokenType.REFRESH);
+        String newAccessToken = jwtLoginProvider.generateAccessToken(spaceMember.getSpaceId(), spaceMember.getId());
+        String newRefreshToken = jwtLoginProvider.generateRefreshToken(spaceMember.getUserId());
 
         createRefreshTokenPort.create(spaceMember.getUserId(), newRefreshToken);
 

--- a/src/main/java/space/space_spring/global/argumentResolver/jwtLogin/JwtAuthorizationArgumentResolver.java
+++ b/src/main/java/space/space_spring/global/argumentResolver/jwtLogin/JwtAuthorizationArgumentResolver.java
@@ -1,0 +1,24 @@
+package space.space_spring.global.argumentResolver.jwtLogin;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class JwtAuthorizationArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(JwtLoginAuth.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        return request.getAttribute("spaceMemberId");
+    }
+}

--- a/src/main/java/space/space_spring/global/argumentResolver/jwtLogin/JwtSpaceId.java
+++ b/src/main/java/space/space_spring/global/argumentResolver/jwtLogin/JwtSpaceId.java
@@ -1,0 +1,11 @@
+package space.space_spring.global.argumentResolver.jwtLogin;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JwtSpaceId {
+}

--- a/src/main/java/space/space_spring/global/argumentResolver/jwtLogin/JwtSpaceIdArgumentResolver.java
+++ b/src/main/java/space/space_spring/global/argumentResolver/jwtLogin/JwtSpaceIdArgumentResolver.java
@@ -9,17 +9,16 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
-public class JwtLoginAuthHandlerArgumentResolver implements HandlerMethodArgumentResolver {
+public class JwtSpaceIdArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        // 일단 parameter의 return value type 을 검사하지는 X
-        return parameter.hasParameterAnnotation(JwtLoginAuth.class);
+        return parameter.hasParameterAnnotation(JwtSpaceId.class);
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        return request.getAttribute("spaceMemberId");          // jwt를 복호화해서 얻은 userId get
+        return request.getAttribute("spaceId");
     }
 }

--- a/src/main/java/space/space_spring/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/global/common/response/status/BaseExceptionResponseStatus.java
@@ -45,7 +45,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     EXPIRED_REFRESH_TOKEN(4009, HttpStatus.UNAUTHORIZED, "만료된 refresh token 입니다. 다시 로그인해야합니다."),
     DISCORD_TOKEN_ERROR(4010, HttpStatus.UNAUTHORIZED, "디스코드 서버에서 access token 발급이 실패하였습니다."),
     CANNOT_FIND_DISCORD_USER(4011, HttpStatus.NOT_FOUND, "디스코드 계정의 정보를 가져오는 데에 실패하였습니다."),
-    INVALID_REFRESH_TOKEN(4012, HttpStatus.NOT_FOUND, "유효하지 않은 refresh token입니다."),
+    INVALID_REFRESH_TOKEN(4012, HttpStatus.UNAUTHORIZED, "유효하지 않은 refresh token입니다."),
 
     /**
      * 5000: User 오류

--- a/src/main/java/space/space_spring/global/config/WebConfig.java
+++ b/src/main/java/space/space_spring/global/config/WebConfig.java
@@ -8,24 +8,27 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import space.space_spring.global.argumentResolver.jwtLogin.JwtLoginAuthHandlerArgumentResolver;
+import space.space_spring.global.argumentResolver.jwtLogin.JwtAuthorizationArgumentResolver;
+import space.space_spring.global.argumentResolver.jwtLogin.JwtSpaceIdArgumentResolver;
 import space.space_spring.global.config.interceptorURL.JwtLoginInterceptorURL;
-import space.space_spring.global.interceptor.jwtLogin.JwtLoginAuthInterceptor;
+import space.space_spring.global.interceptor.jwtLogin.JwtAuthInterceptor;
 
 
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final JwtLoginAuthInterceptor jwtLoginAuthInterceptor;
+    private final JwtAuthInterceptor jwtAuthInterceptor;
 
-    private final JwtLoginAuthHandlerArgumentResolver jwtLoginAuthHandlerArgumentResolver;
+    private final JwtAuthorizationArgumentResolver jwtAuthorizationArgumentResolver;
+
+    private final JwtSpaceIdArgumentResolver jwtSpaceIdArgumentResolver;
 
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         InterceptorRegistration registration =
-                registry.addInterceptor(jwtLoginAuthInterceptor)
+                registry.addInterceptor(jwtAuthInterceptor)
                 .order(1);
 
         for (JwtLoginInterceptorURL interceptorURL : JwtLoginInterceptorURL.values()) {
@@ -35,7 +38,8 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
-        argumentResolvers.add(jwtLoginAuthHandlerArgumentResolver);
+        argumentResolvers.add(jwtAuthorizationArgumentResolver);
+        argumentResolvers.add(jwtSpaceIdArgumentResolver);
     }
 
     @Override

--- a/src/test/java/space/space_spring/domain/user/application/service/DiscordOauthServiceTest.java
+++ b/src/test/java/space/space_spring/domain/user/application/service/DiscordOauthServiceTest.java
@@ -54,8 +54,8 @@ public class DiscordOauthServiceTest {
         //given
         Mockito.when(loadUserPort.loadUserByDiscordId(user.getDiscordId())).thenReturn(Optional.ofNullable(user));
         Mockito.when(loadSpaceMemberPort.loadByUserId(user.getId())).thenReturn(spaceMember);
-        Mockito.when(jwtLoginProvider.generateToken(user.getId(), spaceMember.getId(), TokenType.ACCESS)).thenReturn("result-access-token");
-        Mockito.when(jwtLoginProvider.generateToken(user.getId(), spaceMember.getId(), TokenType.REFRESH)).thenReturn("result-refresh-token");
+        Mockito.when(jwtLoginProvider.generateAccessToken(spaceMember.getSpaceId(), spaceMember.getId())).thenReturn("result-access-token");
+        Mockito.when(jwtLoginProvider.generateRefreshToken(user.getId())).thenReturn("result-refresh-token");
 
         //when
         TokenPair tokenPair = discordOauthService.signIn(code);

--- a/src/test/java/space/space_spring/domain/user/application/service/DiscordOauthServiceTest.java
+++ b/src/test/java/space/space_spring/domain/user/application/service/DiscordOauthServiceTest.java
@@ -54,8 +54,8 @@ public class DiscordOauthServiceTest {
         //given
         Mockito.when(loadUserPort.loadUserByDiscordId(user.getDiscordId())).thenReturn(Optional.ofNullable(user));
         Mockito.when(loadSpaceMemberPort.loadByUserId(user.getId())).thenReturn(spaceMember);
-        Mockito.when(jwtLoginProvider.generateToken(user.getId(), TokenType.ACCESS)).thenReturn("result-access-token");
-        Mockito.when(jwtLoginProvider.generateToken(user.getId(), TokenType.REFRESH)).thenReturn("result-refresh-token");
+        Mockito.when(jwtLoginProvider.generateToken(user.getId(), spaceMember.getId(), TokenType.ACCESS)).thenReturn("result-access-token");
+        Mockito.when(jwtLoginProvider.generateToken(user.getId(), spaceMember.getId(), TokenType.REFRESH)).thenReturn("result-refresh-token");
 
         //when
         TokenPair tokenPair = discordOauthService.signIn(code);

--- a/src/test/java/space/space_spring/domain/user/application/service/TokenServiceTest.java
+++ b/src/test/java/space/space_spring/domain/user/application/service/TokenServiceTest.java
@@ -58,8 +58,8 @@ public class TokenServiceTest {
     void updateTokenPair() {
         //given
         Mockito.when(jwtLoginProvider.isExpiredToken(refreshToken, TokenType.REFRESH)).thenReturn(false);
-        Mockito.when(jwtLoginProvider.generateToken(spaceMember.getUserId(), spaceMember.getId(), TokenType.ACCESS)).thenReturn("new-access-token");
-        Mockito.when(jwtLoginProvider.generateToken(spaceMember.getUserId(), spaceMember.getId(), TokenType.REFRESH)).thenReturn("new-refresh-token");
+        Mockito.when(jwtLoginProvider.generateAccessToken(spaceMember.getSpaceId(), spaceMember.getId())).thenReturn("new-access-token");
+        Mockito.when(jwtLoginProvider.generateRefreshToken(spaceMember.getUserId())).thenReturn("new-refresh-token");
 
         //when
         TokenPair expiredTokenPair = new TokenPair(accessToken, refreshToken);

--- a/src/test/java/space/space_spring/domain/user/application/service/TokenServiceTest.java
+++ b/src/test/java/space/space_spring/domain/user/application/service/TokenServiceTest.java
@@ -58,8 +58,8 @@ public class TokenServiceTest {
     void updateTokenPair() {
         //given
         Mockito.when(jwtLoginProvider.isExpiredToken(refreshToken, TokenType.REFRESH)).thenReturn(false);
-        Mockito.when(jwtLoginProvider.generateToken(spaceMember.getId(), TokenType.ACCESS)).thenReturn("new-access-token");
-        Mockito.when(jwtLoginProvider.generateToken(spaceMember.getId(), TokenType.REFRESH)).thenReturn("new-refresh-token");
+        Mockito.when(jwtLoginProvider.generateToken(spaceMember.getUserId(), spaceMember.getId(), TokenType.ACCESS)).thenReturn("new-access-token");
+        Mockito.when(jwtLoginProvider.generateToken(spaceMember.getUserId(), spaceMember.getId(), TokenType.REFRESH)).thenReturn("new-refresh-token");
 
         //when
         TokenPair expiredTokenPair = new TokenPair(accessToken, refreshToken);


### PR DESCRIPTION
## 📝 요약

- resolved #238 

## 🔖 변경 사항
- access token 페이로드에 `spaceId` 추가 + interceptor에서 URL과의 id 비교 및 검증 + `@JwtSpaceId` 커스텀 어노테이션 생성
- refresh token 페이로드 `userId`로 변경
- refresh token 저장 시 Redis 자료구조 변경

## ✅ 리뷰 요구사항
로직에 문제가 있는지 한 번 봐주시면 좋을 것 같습니다.

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
