### PR TITLE
Feat/#249/정산 api 마무리

### DIFF
--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/completePay/CompletePayController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/completePay/CompletePayController.java
@@ -1,5 +1,7 @@
 package space.space_spring.domain.pay.adapter.in.web.completePay;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,10 +13,16 @@ import space.space_spring.global.common.response.SuccessResponse;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Pay", description = "정산 관련 API")
 public class CompletePayController {
 
     private final CompletePayUseCase completePayUseCase;
 
+    @Operation(summary = "정산 완료 처리(= 송금 완료 처리)", description = """
+            
+            정산 요청의 대상자가 정산 완료 처리(= 송금 완료 처리)를 합니다.
+            
+            """)
     @PatchMapping("/space/{spaceId}/pay/{payRequestTargetId}/complete")
     public BaseResponse<SuccessResponse> completeForRequestedPay(@JwtLoginAuth Long spaceMemberId, @PathVariable("payRequestTargetId") Long payRequestTargetId) {
         completePayUseCase.completeForRequestedPay(spaceMemberId, payRequestTargetId);

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/completePay/CompletePayController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/completePay/CompletePayController.java
@@ -16,11 +16,7 @@ public class CompletePayController {
     private final CompletePayUseCase completePayUseCase;
 
     @PatchMapping("/space/{spaceId}/pay/{payRequestTargetId}/complete")
-    public BaseResponse<SuccessResponse> completeForRequestedPay(@JwtLoginAuth Long spaceMemberId, @PathVariable("spaceId") Long spaceId, @PathVariable("payRequestTargetId") Long payRequestTargetId) {
-        /**
-         * 토큰 수정하면 토큰 spaceId == url spaceId 확인하는 validation 추가
-         */
-
+    public BaseResponse<SuccessResponse> completeForRequestedPay(@JwtLoginAuth Long spaceMemberId, @PathVariable("payRequestTargetId") Long payRequestTargetId) {
         completePayUseCase.completeForRequestedPay(spaceMemberId, payRequestTargetId);
         return new BaseResponse<>(new SuccessResponse(true));
     }

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/createPay/CreatePayController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/createPay/CreatePayController.java
@@ -21,7 +21,7 @@ public class CreatePayController {
     private final CreatePayUseCase createPayUseCase;
 
     @PostMapping("/space/{spaceId}/pay/create")
-    public BaseResponse<Long> createPay(@JwtLoginAuth Long spaceMemberId, @Validated @RequestBody RequestOfCreatePay request, BindingResult bindingResult) {
+    public BaseResponse<ResponseOfCreatePay> createPay(@JwtLoginAuth Long spaceMemberId, @Validated @RequestBody RequestOfCreatePay request, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             throw new CustomException(INVALID_PAY_CREATE, getErrorMessage(bindingResult));
         }
@@ -35,6 +35,6 @@ public class CreatePayController {
                 .valueOfPayType(request.getValueOfPayType())
                 .build();
 
-        return new BaseResponse<>(createPayUseCase.createPay(createPayCommand));
+        return new BaseResponse<>(ResponseOfCreatePay.of(createPayUseCase.createPay(createPayCommand)));
     }
 }

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/createPay/CreatePayController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/createPay/CreatePayController.java
@@ -21,17 +21,13 @@ public class CreatePayController {
     private final CreatePayUseCase createPayUseCase;
 
     @PostMapping("/space/{spaceId}/pay/create")
-    public BaseResponse<Long> createPay(@JwtLoginAuth Long id, @PathVariable Long spaceId, @Validated @RequestBody RequestOfCreatePay request, BindingResult bindingResult) {
-        /**
-         * 토큰 수정하면 토큰 spaceId == url spaceId 확인하는 validation 추가
-         */
-
+    public BaseResponse<Long> createPay(@JwtLoginAuth Long spaceMemberId, @Validated @RequestBody RequestOfCreatePay request, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             throw new CustomException(INVALID_PAY_CREATE, getErrorMessage(bindingResult));
         }
 
         CreatePayCommand createPayCommand = CreatePayCommand.builder()
-                .payCreatorId(id)
+                .payCreatorId(spaceMemberId)
                 .totalAmount(request.getTotalAmount())
                 .bankName(request.getBankName())
                 .bankAccountNum(request.getBankAccountNum())

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/createPay/CreatePayController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/createPay/CreatePayController.java
@@ -1,5 +1,7 @@
 package space.space_spring.domain.pay.adapter.in.web.createPay;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.graphql.ConditionalOnGraphQlSchema;
 import org.springframework.validation.BindingResult;
@@ -16,10 +18,16 @@ import static space.space_spring.global.util.bindingResult.BindingResultUtils.ge
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Pay", description = "정산 관련 API")
 public class CreatePayController {
 
     private final CreatePayUseCase createPayUseCase;
 
+    @Operation(summary = "정산 요청 생성", description = """
+            
+            스페이스 멤버가 같은 스페이스에 속한 멤버들에게 정산 요청을 생성합니다.
+            
+            """)
     @PostMapping("/space/{spaceId}/pay/create")
     public BaseResponse<ResponseOfCreatePay> createPay(@JwtLoginAuth Long spaceMemberId, @Validated @RequestBody RequestOfCreatePay request, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/createPay/ResponseOfCreatePay.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/createPay/ResponseOfCreatePay.java
@@ -1,0 +1,17 @@
+package space.space_spring.domain.pay.adapter.in.web.createPay;
+
+import lombok.Getter;
+
+@Getter
+public class ResponseOfCreatePay {
+
+    private Long payRequestId;
+
+    private ResponseOfCreatePay(Long payRequestId) {
+        this.payRequestId = payRequestId;
+    }
+
+    public static ResponseOfCreatePay of(Long payRequestId) {
+        return new ResponseOfCreatePay(payRequestId);
+    }
+}

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/deletePay/DeletePayController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/deletePay/DeletePayController.java
@@ -1,5 +1,7 @@
 package space.space_spring.domain.pay.adapter.in.web.deletePay;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,10 +13,16 @@ import space.space_spring.global.common.response.SuccessResponse;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Pay", description = "정산 관련 API")
 public class DeletePayController {
 
     private final DeletePayUseCase deletePayUseCase;
 
+    @Operation(summary = "정산 요청 삭제", description = """
+            
+            정산 요청을 생성한 멤버가 해당 정산 요청을 삭제합니다.
+            
+            """)
     @DeleteMapping("/space/{spaceId}/pay/{payRequestId}")
     public BaseResponse<SuccessResponse> deletePay(@JwtLoginAuth Long spaceMemberId, @PathVariable("payRequestId") Long payRequestId) {
         deletePayUseCase.deletePay(spaceMemberId, payRequestId);

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/deletePay/DeletePayController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/deletePay/DeletePayController.java
@@ -1,0 +1,23 @@
+package space.space_spring.domain.pay.adapter.in.web.deletePay;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import space.space_spring.domain.pay.application.port.in.deletePay.DeletePayUseCase;
+import space.space_spring.global.argumentResolver.jwtLogin.JwtLoginAuth;
+import space.space_spring.global.common.response.BaseResponse;
+import space.space_spring.global.common.response.SuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+public class DeletePayController {
+
+    private final DeletePayUseCase deletePayUseCase;
+
+    @DeleteMapping("/space/{spaceId}/pay/{payRequestId}")
+    public BaseResponse<SuccessResponse> deletePay(@JwtLoginAuth Long spaceMemberId, @PathVariable("payRequestId") Long payRequestId) {
+        deletePayUseCase.deletePay(spaceMemberId, payRequestId);
+        return new BaseResponse<>(new SuccessResponse(true));
+    }
+}

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readBankInfo/BankInfo.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readBankInfo/BankInfo.java
@@ -1,0 +1,19 @@
+package space.space_spring.domain.pay.adapter.in.web.readBankInfo;
+
+import space.space_spring.domain.pay.domain.Bank;
+
+public class BankInfo {
+
+    private String bankName;
+
+    private String bankAccountNumber;
+
+    private BankInfo(String bankName, String bankAccountNumber) {
+        this.bankName = bankName;
+        this.bankAccountNumber = bankAccountNumber;
+    }
+
+    public static BankInfo of(Bank bank) {
+        return new BankInfo(bank.getName(), bank.getAccountNumber());
+    }
+}

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readBankInfo/BankInfo.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readBankInfo/BankInfo.java
@@ -1,7 +1,9 @@
 package space.space_spring.domain.pay.adapter.in.web.readBankInfo;
 
+import lombok.Getter;
 import space.space_spring.domain.pay.domain.Bank;
 
+@Getter
 public class BankInfo {
 
     private String bankName;

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readBankInfo/ReadBankInfoController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readBankInfo/ReadBankInfoController.java
@@ -1,5 +1,7 @@
 package space.space_spring.domain.pay.adapter.in.web.readBankInfo;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,10 +11,16 @@ import space.space_spring.global.common.response.BaseResponse;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Pay", description = "정산 관련 API")
 public class ReadBankInfoController {
 
     private final ReadBankInfoUseCase readBankInfoUseCase;
 
+    @Operation(summary = "과거 정산받은 은행정보 조회", description = """
+            
+            스페이스 멤버가 과거에 정산받은 은행 정보를 조회힙니다.
+            
+            """)
     @GetMapping("/space/{spaceId}/pay/bank")
     public BaseResponse<ResponseOfBankInfo> showBankInfo(@JwtLoginAuth Long spaceMemberId) {
         return new BaseResponse<>(ResponseOfBankInfo.of(readBankInfoUseCase.readBankInfo(spaceMemberId)));

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readBankInfo/ReadBankInfoController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readBankInfo/ReadBankInfoController.java
@@ -1,0 +1,20 @@
+package space.space_spring.domain.pay.adapter.in.web.readBankInfo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import space.space_spring.domain.pay.application.port.in.readBankInfo.ReadBankInfoUseCase;
+import space.space_spring.global.argumentResolver.jwtLogin.JwtLoginAuth;
+import space.space_spring.global.common.response.BaseResponse;
+
+@RestController
+@RequiredArgsConstructor
+public class ReadBankInfoController {
+
+    private final ReadBankInfoUseCase readBankInfoUseCase;
+
+    @GetMapping("/space/{spaceId}/pay/bank")
+    public BaseResponse<ResponseOfBankInfo> showBankInfo(@JwtLoginAuth Long spaceMemberId) {
+        return new BaseResponse<>(ResponseOfBankInfo.of(readBankInfoUseCase.readBankInfo(spaceMemberId)));
+    }
+}

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readBankInfo/ResponseOfBankInfo.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readBankInfo/ResponseOfBankInfo.java
@@ -1,10 +1,12 @@
 package space.space_spring.domain.pay.adapter.in.web.readBankInfo;
 
+import lombok.Getter;
 import space.space_spring.domain.pay.domain.Bank;
 
 import java.util.List;
 import java.util.Set;
 
+@Getter
 public class ResponseOfBankInfo {
 
     private List<BankInfo> bankInfos;

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readBankInfo/ResponseOfBankInfo.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readBankInfo/ResponseOfBankInfo.java
@@ -1,0 +1,21 @@
+package space.space_spring.domain.pay.adapter.in.web.readBankInfo;
+
+import space.space_spring.domain.pay.domain.Bank;
+
+import java.util.List;
+import java.util.Set;
+
+public class ResponseOfBankInfo {
+
+    private List<BankInfo> bankInfos;
+
+    private ResponseOfBankInfo(List<BankInfo> bankInfos) {
+        this.bankInfos = bankInfos;
+    }
+
+    public static ResponseOfBankInfo of(Set<Bank> banks) {
+        return new ResponseOfBankInfo(banks.stream()
+                .map(BankInfo::of)
+                .toList());
+    }
+}

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayDetail/ReadSinglePayController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayDetail/ReadSinglePayController.java
@@ -20,11 +20,7 @@ public class ReadSinglePayController {
     private final ReadPayDetailUseCase readPayDetailUseCase;
 
     @GetMapping("/space/{spaceId}/pay/{payRequestId}")
-    public BaseResponse<ResponseOfReadPayDetail> showPayDetail(@JwtLoginAuth Long spaceMemberId, @PathVariable("spaceId") Long spaceId, @PathVariable("payRequestId") Long payRequestId) {
-        /**
-         * 토큰 수정하면 토큰 spaceId == url spaceId 확인하는 validation 추가
-         */
-
+    public BaseResponse<ResponseOfReadPayDetail> showPayDetail(@JwtLoginAuth Long spaceMemberId, @PathVariable("payRequestId") Long payRequestId) {
         return new BaseResponse<>(ResponseOfReadPayDetail.of(readPayDetailUseCase.readPayDetail(spaceMemberId, payRequestId)));
     }
 }

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayDetail/ReadSinglePayController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayDetail/ReadSinglePayController.java
@@ -1,5 +1,7 @@
 package space.space_spring.domain.pay.adapter.in.web.readPayDetail;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,6 +13,7 @@ import space.space_spring.global.common.response.BaseResponse;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Pay", description = "정산 관련 API")
 public class ReadSinglePayController {
 
     /**
@@ -19,6 +22,11 @@ public class ReadSinglePayController {
 
     private final ReadPayDetailUseCase readPayDetailUseCase;
 
+    @Operation(summary = "정산 요청 상세 조회", description = """
+            
+            정산 요청을 생성한 멤버가 해당 정산 요청의 상세 정보를 조회힙니다.
+            
+            """)
     @GetMapping("/space/{spaceId}/pay/{payRequestId}")
     public BaseResponse<ResponseOfReadPayDetail> showPayDetail(@JwtLoginAuth Long spaceMemberId, @PathVariable("payRequestId") Long payRequestId) {
         return new BaseResponse<>(ResponseOfReadPayDetail.of(readPayDetailUseCase.readPayDetail(spaceMemberId, payRequestId)));

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayDetail/ResponseOfReadPayDetail.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayDetail/ResponseOfReadPayDetail.java
@@ -1,11 +1,13 @@
 package space.space_spring.domain.pay.adapter.in.web.readPayDetail;
 
 import lombok.Builder;
+import lombok.Getter;
 import space.space_spring.domain.pay.application.port.in.readPayDetail.ResultOfReadPayDetail;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+@Getter
 public class ResponseOfReadPayDetail {
 
     private static final String DATE_FORMAT = "yyyy-MM-dd";

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayDetail/ResponseOfTargetDetail.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayDetail/ResponseOfTargetDetail.java
@@ -1,8 +1,10 @@
 package space.space_spring.domain.pay.adapter.in.web.readPayDetail;
 
 import lombok.Builder;
+import lombok.Getter;
 import space.space_spring.domain.pay.application.port.in.readPayDetail.InfoOfTargetDetail;
 
+@Getter
 public class ResponseOfTargetDetail {
 
     private Long targetMemberId;

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayHome/ReadPayHomeController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayHome/ReadPayHomeController.java
@@ -16,11 +16,7 @@ public class ReadPayHomeController {
     private final ReadPayHomeUseCase readPayHomeUseCase;
 
     @GetMapping("/space/{spaceId}/pay")
-    public BaseResponse<ResponseOfReadPayHome> showHomeView(@JwtLoginAuth Long spaceMemberId, @PathVariable Long spaceId) {
-        /**
-         * 토큰 수정하면 토큰 spaceId == url spaceId 확인하는 validation 추가
-         */
-
+    public BaseResponse<ResponseOfReadPayHome> showHomeView(@JwtLoginAuth Long spaceMemberId) {
         return new BaseResponse<>(ResponseOfReadPayHome.of(readPayHomeUseCase.readPayHome(spaceMemberId)));
     }
 }

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayHome/ReadPayHomeController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayHome/ReadPayHomeController.java
@@ -1,5 +1,7 @@
 package space.space_spring.domain.pay.adapter.in.web.readPayHome;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,10 +13,16 @@ import space.space_spring.global.common.response.BaseResponse;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Pay", description = "정산 관련 API")
 public class ReadPayHomeController {
 
     private final ReadPayHomeUseCase readPayHomeUseCase;
 
+    @Operation(summary = "정산 홈 조회", description = """
+            
+            스페이스 멤버가 정산 홈 화면을 조회힙니다.
+            
+            """)
     @GetMapping("/space/{spaceId}/pay")
     public BaseResponse<ResponseOfReadPayHome> showHomeView(@JwtLoginAuth Long spaceMemberId) {
         return new BaseResponse<>(ResponseOfReadPayHome.of(readPayHomeUseCase.readPayHome(spaceMemberId)));

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayHome/RequestedPayInfoInHome.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayHome/RequestedPayInfoInHome.java
@@ -6,7 +6,7 @@ import space.space_spring.domain.pay.application.port.in.readPayHome.InfoOfReque
 @Getter
 public class RequestedPayInfoInHome {
 
-    private Long payRequestedTargetId;
+    private Long payRequestTargetId;
 
     private String payCreatorName;
 
@@ -14,8 +14,8 @@ public class RequestedPayInfoInHome {
 
     private int requestedAmount;
 
-    private RequestedPayInfoInHome(Long payRequestedTargetId, String payCreatorName, String payCreatorProfileImgUrl, int requestedAmount) {
-        this.payRequestedTargetId = payRequestedTargetId;
+    private RequestedPayInfoInHome(Long payRequestTargetId, String payCreatorName, String payCreatorProfileImgUrl, int requestedAmount) {
+        this.payRequestTargetId = payRequestTargetId;
         this.payCreatorName = payCreatorName;
         this.payCreatorProfileImgUrl = payCreatorProfileImgUrl;
         this.requestedAmount = requestedAmount;

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayHome/ResponseOfReadPayHome.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayHome/ResponseOfReadPayHome.java
@@ -1,11 +1,13 @@
 package space.space_spring.domain.pay.adapter.in.web.readPayHome;
 
+import lombok.Getter;
 import space.space_spring.domain.pay.application.port.in.readPayHome.InfoOfPayRequestInHome;
 import space.space_spring.domain.pay.application.port.in.readPayHome.InfoOfRequestedPayInHome;
 import space.space_spring.domain.pay.application.port.in.readPayHome.ResultOfPayHomeView;
 
 import java.util.List;
 
+@Getter
 public class ResponseOfReadPayHome {
 
     private List<PayRequestInfoInHome> requestInfoInHome;

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayRequestList/ReadPayRequestListController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayRequestList/ReadPayRequestListController.java
@@ -20,11 +20,7 @@ public class ReadPayRequestListController {
     private final ReadPayRequestListUseCase readPayRequestListUseCase;
 
     @GetMapping("/space/{spaceId}/pay/request")
-    public BaseResponse<ResponseOfReadPayRequestList> showPayRequestList(@JwtLoginAuth Long id, @PathVariable Long spaceId) {
-        /**
-         * 토큰 수정하면 토큰 spaceId == url spaceId 확인하는 validation 추가
-         */
-
-        return new BaseResponse<>(ResponseOfReadPayRequestList.of(readPayRequestListUseCase.readPayRequestList(id)));
+    public BaseResponse<ResponseOfReadPayRequestList> showPayRequestList(@JwtLoginAuth Long spaceMemberId) {
+        return new BaseResponse<>(ResponseOfReadPayRequestList.of(readPayRequestListUseCase.readPayRequestList(spaceMemberId)));
     }
 }

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayRequestList/ReadPayRequestListController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayRequestList/ReadPayRequestListController.java
@@ -1,5 +1,7 @@
 package space.space_spring.domain.pay.adapter.in.web.readPayRequestList;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,6 +13,7 @@ import space.space_spring.global.common.response.BaseResponse;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Pay", description = "정산 관련 API")
 public class ReadPayRequestListController {
 
     /**
@@ -19,6 +22,11 @@ public class ReadPayRequestListController {
 
     private final ReadPayRequestListUseCase readPayRequestListUseCase;
 
+    @Operation(summary = "스페이스 멤버가 요청한 정산 요청 목록 조회", description = """
+            
+            스페이스 멤버가 요청한 모든 정산 요청들을 조회힙니다.
+            
+            """)
     @GetMapping("/space/{spaceId}/pay/request")
     public BaseResponse<ResponseOfReadPayRequestList> showPayRequestList(@JwtLoginAuth Long spaceMemberId) {
         return new BaseResponse<>(ResponseOfReadPayRequestList.of(readPayRequestListUseCase.readPayRequestList(spaceMemberId)));

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayRequestList/ResponseOfReadPayRequestList.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readPayRequestList/ResponseOfReadPayRequestList.java
@@ -1,11 +1,13 @@
 package space.space_spring.domain.pay.adapter.in.web.readPayRequestList;
 
+import lombok.Getter;
 import space.space_spring.domain.pay.application.port.in.readPayRequestList.InfoOfPayRequest;
 import space.space_spring.domain.pay.application.port.in.readPayRequestList.ResultOfReadPayRequestList;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Getter
 public class ResponseOfReadPayRequestList {
 
     private List<ResponseOfPayRequestInfo> completePayRequestList;

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readRequestedPayList/ReadRequestedPayListController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readRequestedPayList/ReadRequestedPayListController.java
@@ -1,5 +1,7 @@
 package space.space_spring.domain.pay.adapter.in.web.readRequestedPayList;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,6 +13,7 @@ import space.space_spring.global.common.response.BaseResponse;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Pay", description = "정산 관련 API")
 public class ReadRequestedPayListController {
 
     /**
@@ -19,6 +22,11 @@ public class ReadRequestedPayListController {
 
     private final ReadRequestedPayListUseCase readRequestedPayListUseCase;
 
+    @Operation(summary = "스페이스 멤버가 요청받은 정산 요청 목록 조회", description = """
+            
+            스페이스 멤버가 요청받은 모든 정산 요청 목록을 조회합니다.
+            
+            """)
     @GetMapping("/space/{spaceId}/pay/requested")
     public BaseResponse<ResponseOfReadRequestedPayList> showRequestedPayList(@JwtLoginAuth Long spaceMemberId) {
         return new BaseResponse<>(ResponseOfReadRequestedPayList.of(readRequestedPayListUseCase.readRequestedPayList(spaceMemberId)));

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readRequestedPayList/ReadRequestedPayListController.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readRequestedPayList/ReadRequestedPayListController.java
@@ -20,12 +20,8 @@ public class ReadRequestedPayListController {
     private final ReadRequestedPayListUseCase readRequestedPayListUseCase;
 
     @GetMapping("/space/{spaceId}/pay/requested")
-    public BaseResponse<ResponseOfReadRequestedPayList> showRequestedPayList(@JwtLoginAuth Long id, @PathVariable Long spaceId) {
-        /**
-         * 토큰 수정하면 토큰 spaceId == url spaceId 확인하는 validation 추가
-         */
-
-        return new BaseResponse<>(ResponseOfReadRequestedPayList.of(readRequestedPayListUseCase.readRequestedPayList(id)));
+    public BaseResponse<ResponseOfReadRequestedPayList> showRequestedPayList(@JwtLoginAuth Long spaceMemberId) {
+        return new BaseResponse<>(ResponseOfReadRequestedPayList.of(readRequestedPayListUseCase.readRequestedPayList(spaceMemberId)));
     }
 
 }

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readRequestedPayList/ResponseOfReadRequestedPayList.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readRequestedPayList/ResponseOfReadRequestedPayList.java
@@ -1,11 +1,13 @@
 package space.space_spring.domain.pay.adapter.in.web.readRequestedPayList;
 
+import lombok.Getter;
 import space.space_spring.domain.pay.application.port.in.readRequestedPayList.InfoOfRequestedPay;
 import space.space_spring.domain.pay.application.port.in.readRequestedPayList.ResultOfReadRequestedPayList;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Getter
 public class ResponseOfReadRequestedPayList {
 
     private List<ResponseOfRequestedPayInfo> completeRequestedPayList;

--- a/src/main/java/space/space_spring/domain/pay/adapter/in/web/readRequestedPayList/ResponseOfRequestedPayInfo.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/in/web/readRequestedPayList/ResponseOfRequestedPayInfo.java
@@ -1,10 +1,12 @@
 package space.space_spring.domain.pay.adapter.in.web.readRequestedPayList;
 
+import lombok.Getter;
 import space.space_spring.domain.pay.application.port.in.readRequestedPayList.InfoOfRequestedPay;
 
+@Getter
 public class ResponseOfRequestedPayInfo {
 
-    private Long payRequestedTargetId;
+    private Long payRequestTargetId;
 
     private String payCreatorName;
 
@@ -16,8 +18,8 @@ public class ResponseOfRequestedPayInfo {
 
     private String bankAccountNum;          // 송금할 은행 정보
 
-    private ResponseOfRequestedPayInfo(Long payRequestedTargetId, String payCreatorName, String payCreatorProfileImageUrl, int requestedAmount, String bankName, String bankAccountNum) {
-        this.payRequestedTargetId = payRequestedTargetId;
+    private ResponseOfRequestedPayInfo(Long payRequestTargetId, String payCreatorName, String payCreatorProfileImageUrl, int requestedAmount, String bankName, String bankAccountNum) {
+        this.payRequestTargetId = payRequestTargetId;
         this.payCreatorName = payCreatorName;
         this.payCreatorProfileImageUrl = payCreatorProfileImageUrl;
         this.requestedAmount = requestedAmount;

--- a/src/main/java/space/space_spring/domain/pay/adapter/out/persistence/SpringDataPayRequestRepository.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/out/persistence/SpringDataPayRequestRepository.java
@@ -3,6 +3,7 @@ package space.space_spring.domain.pay.adapter.out.persistence;
 import org.springframework.data.jpa.repository.JpaRepository;
 import space.space_spring.domain.pay.adapter.out.persistence.jpaEntity.PayRequestJpaEntity;
 import space.space_spring.domain.spaceMember.domian.SpaceMemberJpaEntity;
+import space.space_spring.global.common.enumStatus.BaseStatusType;
 
 
 import java.util.List;
@@ -10,5 +11,7 @@ import java.util.Optional;
 
 public interface SpringDataPayRequestRepository extends JpaRepository<PayRequestJpaEntity, Long> {
 
-    Optional<List<PayRequestJpaEntity>> findListByPayCreator(SpaceMemberJpaEntity payCreator);
+    Optional<List<PayRequestJpaEntity>> findListByPayCreatorAndStatus(SpaceMemberJpaEntity payCreator, BaseStatusType baseStatusType);
+
+    Optional<PayRequestJpaEntity> findByIdAndStatus(Long id, BaseStatusType baseStatusType);
 }

--- a/src/main/java/space/space_spring/domain/pay/adapter/out/persistence/SpringDataPayRequestTargetRepository.java
+++ b/src/main/java/space/space_spring/domain/pay/adapter/out/persistence/SpringDataPayRequestTargetRepository.java
@@ -4,13 +4,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import space.space_spring.domain.pay.adapter.out.persistence.jpaEntity.PayRequestJpaEntity;
 import space.space_spring.domain.pay.adapter.out.persistence.jpaEntity.PayRequestTargetJpaEntity;
 import space.space_spring.domain.spaceMember.domian.SpaceMemberJpaEntity;
+import space.space_spring.global.common.enumStatus.BaseStatusType;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface SpringDataPayRequestTargetRepository extends JpaRepository<PayRequestTargetJpaEntity, Long> {
 
-    Optional<List<PayRequestTargetJpaEntity>> findListByTargetMember(SpaceMemberJpaEntity targetMemberJpaEntity);
+    Optional<List<PayRequestTargetJpaEntity>> findListByTargetMemberAndStatus(SpaceMemberJpaEntity targetMemberJpaEntity, BaseStatusType baseStatusType);
 
-    Optional<List<PayRequestTargetJpaEntity>> findByPayRequest(PayRequestJpaEntity payRequestJpaEntity);
+    Optional<List<PayRequestTargetJpaEntity>> findByPayRequestAndStatus(PayRequestJpaEntity payRequestJpaEntity, BaseStatusType baseStatusType);
+
+    Optional<PayRequestTargetJpaEntity> findByIdAndStatus(Long id, BaseStatusType baseStatusType);
+
+    Optional<List<PayRequestTargetJpaEntity>> findAllByIdInAndStatus(List<Long> ids, BaseStatusType baseStatusType);
 }

--- a/src/main/java/space/space_spring/domain/pay/application/port/in/deletePay/DeletePayUseCase.java
+++ b/src/main/java/space/space_spring/domain/pay/application/port/in/deletePay/DeletePayUseCase.java
@@ -1,0 +1,6 @@
+package space.space_spring.domain.pay.application.port.in.deletePay;
+
+public interface DeletePayUseCase {
+
+    void deletePay(Long spaceMemberId, Long payRequestId);
+}

--- a/src/main/java/space/space_spring/domain/pay/application/port/in/readBankInfo/ReadBankInfoUseCase.java
+++ b/src/main/java/space/space_spring/domain/pay/application/port/in/readBankInfo/ReadBankInfoUseCase.java
@@ -1,0 +1,10 @@
+package space.space_spring.domain.pay.application.port.in.readBankInfo;
+
+import space.space_spring.domain.pay.domain.Bank;
+
+import java.util.Set;
+
+public interface ReadBankInfoUseCase {
+
+    Set<Bank> readBankInfo(Long spaceMemberId);
+}

--- a/src/main/java/space/space_spring/domain/pay/application/port/out/DeletePayRequestPort.java
+++ b/src/main/java/space/space_spring/domain/pay/application/port/out/DeletePayRequestPort.java
@@ -1,0 +1,6 @@
+package space.space_spring.domain.pay.application.port.out;
+
+public interface DeletePayRequestPort {
+
+    void deletePayRequest(Long payRequestId);
+}

--- a/src/main/java/space/space_spring/domain/pay/application/port/out/DeletePayRequestTargetPort.java
+++ b/src/main/java/space/space_spring/domain/pay/application/port/out/DeletePayRequestTargetPort.java
@@ -1,0 +1,8 @@
+package space.space_spring.domain.pay.application.port.out;
+
+import java.util.List;
+
+public interface DeletePayRequestTargetPort {
+
+    void deleteAllPayRequestTarget(List<Long> payRequestTargetIds);
+}

--- a/src/main/java/space/space_spring/domain/pay/application/service/CompletePayService.java
+++ b/src/main/java/space/space_spring/domain/pay/application/service/CompletePayService.java
@@ -9,7 +9,7 @@ import space.space_spring.domain.pay.application.port.out.UpdatePayPort;
 import space.space_spring.domain.pay.domain.PayRequestTarget;
 import space.space_spring.global.exception.CustomException;
 
-import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.INVALID_PAY_REQUEST_TARGET_ID;
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.PAY_REQUEST_TARGET_MISMATCH;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +25,7 @@ public class CompletePayService implements CompletePayUseCase {
         PayRequestTarget payRequestTarget = loadPayRequestTargetPort.loadById(payRequestTargetId);
 
         if (!payRequestTarget.isSameTargetMember(targetMemberId)) {
-            throw new CustomException(INVALID_PAY_REQUEST_TARGET_ID);
+            throw new CustomException(PAY_REQUEST_TARGET_MISMATCH);
         }
 
         // 정산 완료 처리

--- a/src/main/java/space/space_spring/domain/pay/application/service/DeletePayService.java
+++ b/src/main/java/space/space_spring/domain/pay/application/service/DeletePayService.java
@@ -1,0 +1,39 @@
+package space.space_spring.domain.pay.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import space.space_spring.domain.pay.application.port.in.deletePay.DeletePayUseCase;
+import space.space_spring.domain.pay.application.port.out.DeletePayRequestPort;
+import space.space_spring.domain.pay.application.port.out.DeletePayRequestTargetPort;
+import space.space_spring.domain.pay.application.port.out.LoadPayRequestPort;
+import space.space_spring.domain.pay.application.port.out.LoadPayRequestTargetPort;
+import space.space_spring.domain.pay.domain.PayRequest;
+import space.space_spring.domain.pay.domain.PayRequestTargets;
+import space.space_spring.global.exception.CustomException;
+
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.PAY_REQUEST_CREATOR_MISMATCH;
+
+@Service
+@RequiredArgsConstructor
+public class DeletePayService implements DeletePayUseCase {
+
+    private final LoadPayRequestPort loadPayRequestPort;
+    private final LoadPayRequestTargetPort loadPayRequestTargetPort;
+    private final DeletePayRequestPort deletePayRequestPort;
+    private final DeletePayRequestTargetPort deletePayRequestTargetPort;
+
+    @Override
+    @Transactional
+    public void deletePay(Long spaceMemberId, Long payRequestId) {
+        PayRequest payRequest = loadPayRequestPort.loadById(payRequestId);
+        if (!payRequest.isPayCreator(spaceMemberId)) {
+            throw new CustomException(PAY_REQUEST_CREATOR_MISMATCH);
+        }
+
+        PayRequestTargets payRequestTargets = PayRequestTargets.create(loadPayRequestTargetPort.loadByPayRequestId(payRequestId));
+        deletePayRequestTargetPort.deleteAllPayRequestTarget(payRequestTargets.getAllTargetIds());
+
+        deletePayRequestPort.deletePayRequest(payRequestId);
+    }
+}

--- a/src/main/java/space/space_spring/domain/pay/application/service/ReadBankInfoService.java
+++ b/src/main/java/space/space_spring/domain/pay/application/service/ReadBankInfoService.java
@@ -1,0 +1,29 @@
+package space.space_spring.domain.pay.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import space.space_spring.domain.pay.application.port.in.readBankInfo.ReadBankInfoUseCase;
+import space.space_spring.domain.pay.application.port.out.LoadPayRequestPort;
+import space.space_spring.domain.pay.domain.Bank;
+import space.space_spring.domain.pay.domain.PayRequest;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReadBankInfoService implements ReadBankInfoUseCase {
+
+    private final LoadPayRequestPort loadPayRequestPort;
+
+    /**
+     * 일단 개수제한, 정렬 없이 전부 반환
+     */
+    @Override
+    public Set<Bank> readBankInfo(Long spaceMemberId) {
+        return loadPayRequestPort.loadByPayCreatorId(spaceMemberId)
+                .stream()
+                .map(PayRequest::getBank)
+                .collect(Collectors.toUnmodifiableSet());       // 중복 제거
+    }
+}

--- a/src/main/java/space/space_spring/domain/pay/application/service/ReadPayDetailService.java
+++ b/src/main/java/space/space_spring/domain/pay/application/service/ReadPayDetailService.java
@@ -15,10 +15,10 @@ import space.space_spring.domain.spaceMember.application.port.out.LoadSpaceMembe
 import space.space_spring.domain.spaceMember.application.port.out.NicknameAndProfileImage;
 import space.space_spring.global.exception.CustomException;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
-import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.INVALID_PAY_REQUEST_ID;
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.PAY_REQUEST_CREATOR_MISMATCH;
+
 
 @Service
 @RequiredArgsConstructor
@@ -50,7 +50,7 @@ public class ReadPayDetailService implements ReadPayDetailUseCase {
     private PayRequest loadAndValidatePayRequest(Long spaceMemberId, Long payRequestId) {
         PayRequest payRequest = loadPayRequestPort.loadById(payRequestId);
         if (!payRequest.isPayCreator(spaceMemberId)) {
-            throw new CustomException(INVALID_PAY_REQUEST_ID);
+            throw new CustomException(PAY_REQUEST_CREATOR_MISMATCH);
         }
         return payRequest;
     }

--- a/src/main/java/space/space_spring/domain/pay/domain/PayRequest.java
+++ b/src/main/java/space/space_spring/domain/pay/domain/PayRequest.java
@@ -3,7 +3,6 @@ package space.space_spring.domain.pay.domain;
 import lombok.Getter;
 
 import space.space_spring.global.common.entity.BaseInfo;
-import space.space_spring.global.common.enumStatus.BaseStatusType;
 import space.space_spring.global.util.NaturalNumber;
 
 
@@ -60,13 +59,5 @@ public class PayRequest {
 
     public boolean isPayCreator(Long spaceMemberId) {
         return payCreatorId.equals(spaceMemberId);
-    }
-
-    public void changeToActive() {
-        this.baseInfo.changeStatus(BaseStatusType.ACTIVE);
-    }
-
-    public void changeToInactive() {
-        this.baseInfo.changeStatus(BaseStatusType.INACTIVE);
     }
 }

--- a/src/main/java/space/space_spring/domain/pay/domain/PayRequestTarget.java
+++ b/src/main/java/space/space_spring/domain/pay/domain/PayRequestTarget.java
@@ -55,12 +55,4 @@ public class PayRequestTarget {
     public void completeForRequestedPay() {
         this.isComplete = true;
     }
-
-    public void changeToActive() {
-        this.baseInfo.changeStatus(BaseStatusType.ACTIVE);
-    }
-
-    public void changeToInactive() {
-        this.baseInfo.changeStatus(BaseStatusType.INACTIVE);
-    }
 }

--- a/src/main/java/space/space_spring/domain/pay/domain/PayRequestTargets.java
+++ b/src/main/java/space/space_spring/domain/pay/domain/PayRequestTargets.java
@@ -71,4 +71,10 @@ public class PayRequestTargets {
 
         return Collections.unmodifiableList(inCompletePayRequestTargetList);
     }
+
+    public List<Long> getAllTargetIds() {
+        return payRequestTargets.stream()
+                .map(PayRequestTarget::getId)
+                .toList();
+    }
 }

--- a/src/main/java/space/space_spring/domain/spaceMember/adapter/out/persistence/SpringDataSpaceMemberRepository.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/adapter/out/persistence/SpringDataSpaceMemberRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import space.space_spring.domain.space.domain.SpaceJpaEntity;
 import space.space_spring.domain.spaceMember.domian.SpaceMember;
 import space.space_spring.domain.spaceMember.domian.SpaceMemberJpaEntity;
+import space.space_spring.global.common.enumStatus.BaseStatusType;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,5 +17,5 @@ public interface SpringDataSpaceMemberRepository extends JpaRepository<SpaceMemb
 
     Optional<SpaceMemberJpaEntity> findBySpaceIdAndDiscordId(Long SpaceId,Long discordId);
 
-
+    Optional<SpaceMemberJpaEntity> findByIdAndStatus(Long id, BaseStatusType baseStatusType);
 }

--- a/src/main/java/space/space_spring/global/common/entity/BaseInfo.java
+++ b/src/main/java/space/space_spring/global/common/entity/BaseInfo.java
@@ -27,8 +27,4 @@ public class BaseInfo {
     public static BaseInfo ofEmpty() {
         return new BaseInfo(null, null, null);
     }
-
-    public void changeStatus(BaseStatusType status) {
-        this.status = status;
-    }
 }

--- a/src/main/java/space/space_spring/global/common/entity/BaseJpaEntity.java
+++ b/src/main/java/space/space_spring/global/common/entity/BaseJpaEntity.java
@@ -53,11 +53,8 @@ public abstract class BaseJpaEntity {
         lastModifiedAt = LocalDateTime.now();
     }
 
-//    protected void initializeBaseEntityFields() {
-//        onCreate();
-//    }
-//
-//    public void updateActive() { this.status = BaseStatusType.ACTIVE; }
-//
-//    public void updateInactive() { this.status = BaseStatusType.INACTIVE; }
+
+    public void updateToActive() { this.status = BaseStatusType.ACTIVE; }
+
+    public void updateToInactive() { this.status = BaseStatusType.INACTIVE; }
 }

--- a/src/main/java/space/space_spring/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/global/common/response/status/BaseExceptionResponseStatus.java
@@ -121,9 +121,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     PAY_REQUEST_NOT_FOUND(12005, HttpStatus.NOT_FOUND, "존재하지 않는 정산입니다."),
     PAY_REQUEST_TARGET_NOT_FOUND(12006, HttpStatus.NOT_FOUND, "존재하지 않는 정산 요청 대상 입니다"),
     THIS_PAY_REQUEST_HAS_NOT_TARGETS(12007, HttpStatus.INTERNAL_SERVER_ERROR, "현재 정산 요청은 정산 요청 대상이 없습니다. 현재 정산 생성 시 서버에 문제가 있었습니다."),
-    INVALID_PAY_REQUEST_TARGET_ID(12008, HttpStatus.BAD_REQUEST, "정산 요청 대상자가 본인과 일치하지 않습니다. 본인의 정산에 대해서만 완료처리를 할 수 있습니다."),
-    INVALID_PAY_REQUEST_ID(12009, HttpStatus.BAD_REQUEST, "정산 생성자가 본인과 일치하지 않습니다. 본인이 생성한 정산에 대해서만 정산 상세 조회가 가능합니다."),
-
+    PAY_REQUEST_TARGET_MISMATCH(12008, HttpStatus.BAD_REQUEST, "정산 요청 대상자가 본인과 일치하지 않습니다."),
+    PAY_REQUEST_CREATOR_MISMATCH(12009, HttpStatus.BAD_REQUEST, "정산 생성자가 본인과 일치하지 않습니다."),
 
     /**
      * 13000 : Event 오류

--- a/src/test/java/space/space_spring/domain/pay/application/service/CompletePayServiceTest.java
+++ b/src/test/java/space/space_spring/domain/pay/application/service/CompletePayServiceTest.java
@@ -14,7 +14,7 @@ import space.space_spring.global.exception.CustomException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
-import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.INVALID_PAY_REQUEST_TARGET_ID;
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.PAY_REQUEST_TARGET_MISMATCH;
 
 class CompletePayServiceTest {
 
@@ -76,7 +76,7 @@ class CompletePayServiceTest {
         // 경민이가 payRequestTarget에 대해서 정산 완료 처리를 요청
         assertThatThrownBy(() -> completePayService.completeForRequestedPay(kyungminId, payRequestTargetId))
                 .isInstanceOf(CustomException.class)
-                .hasMessage(INVALID_PAY_REQUEST_TARGET_ID.getMessage());
+                .hasMessage(PAY_REQUEST_TARGET_MISMATCH.getMessage());
     }
 
 }

--- a/src/test/java/space/space_spring/domain/pay/application/service/DeletePayServiceTest.java
+++ b/src/test/java/space/space_spring/domain/pay/application/service/DeletePayServiceTest.java
@@ -1,0 +1,86 @@
+package space.space_spring.domain.pay.application.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import space.space_spring.domain.pay.application.port.out.DeletePayRequestPort;
+import space.space_spring.domain.pay.application.port.out.DeletePayRequestTargetPort;
+import space.space_spring.domain.pay.application.port.out.LoadPayRequestPort;
+import space.space_spring.domain.pay.application.port.out.LoadPayRequestTargetPort;
+import space.space_spring.domain.pay.domain.*;
+import space.space_spring.global.common.entity.BaseInfo;
+import space.space_spring.global.exception.CustomException;
+import space.space_spring.global.util.NaturalNumber;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.PAY_REQUEST_CREATOR_MISMATCH;
+
+class DeletePayServiceTest {
+
+    private LoadPayRequestPort loadPayRequestPort;
+    private LoadPayRequestTargetPort loadPayRequestTargetPort;
+    private DeletePayRequestPort deletePayRequestPort;
+    private DeletePayRequestTargetPort deletePayRequestTargetPort;
+    private DeletePayService deletePayService;
+
+    private Long seongjunId;
+    private Long sangjunId;
+    private Long seohyunId;
+    private Long kyungminId;
+
+    @BeforeEach
+    void setUp() {
+        loadPayRequestPort = Mockito.mock(LoadPayRequestPort.class);
+        loadPayRequestTargetPort = Mockito.mock(LoadPayRequestTargetPort.class);
+        deletePayRequestPort = Mockito.mock(DeletePayRequestPort.class);
+        deletePayRequestTargetPort = Mockito.mock(DeletePayRequestTargetPort.class);
+        deletePayService = new DeletePayService(loadPayRequestPort, loadPayRequestTargetPort, deletePayRequestPort, deletePayRequestTargetPort);
+
+        seongjunId = 1L;
+        sangjunId = 2L;
+        seohyunId = 3L;
+        kyungminId = 4L;
+    }
+
+    @Test
+    @DisplayName("스페이스 멤버가 생성한 정산 요청, 모든 정산 요청 타겟의 status를 inactive로 변경한다(= soft delete 처리한다).")
+    void deletePay1() throws Exception {
+        //given
+        PayRequest payRequest = PayRequest.create(1L, seongjunId, 1L, Money.of(10000), NaturalNumber.of(3), Bank.of("우리은행", "111-111"), PayType.EQUAL_SPLIT, BaseInfo.ofEmpty());
+        when(loadPayRequestPort.loadById(1L)).thenReturn(payRequest);
+
+        PayRequestTarget target1 = PayRequestTarget.create(1L, sangjunId, 1L, Money.of(3333), BaseInfo.ofEmpty());
+        PayRequestTarget target2 = PayRequestTarget.create(2L, seohyunId, 1L, Money.of(3333), BaseInfo.ofEmpty());
+        PayRequestTarget target3 = PayRequestTarget.create(3L, kyungminId, 1L, Money.of(3333), BaseInfo.ofEmpty());
+        when(loadPayRequestTargetPort.loadByPayRequestId(1L)).thenReturn(List.of(target1, target2, target3));
+
+        //when
+        deletePayService.deletePay(seongjunId, 1L);
+
+        //then
+        List<Long> expectedTargetIds = List.of(target1.getId(), target2.getId(), target3.getId());
+
+        // deleteAllPayRequestTarget 메서드가 정확한 인자값으로 한 번 호출되었는지 검증
+        Mockito.verify(deletePayRequestTargetPort, Mockito.times(1)).deleteAllPayRequestTarget(expectedTargetIds);
+
+        // deletePayRequest 메서드가 payRequestId(= 1L)로 한 번 호출되었는지 검증
+        Mockito.verify(deletePayRequestPort, Mockito.times(1)).deletePayRequest(1L);
+    }
+
+    @Test
+    @DisplayName("본인이 생성하지 않은 정산에 대해 정산 삭제 요청이 들어올 경우, 예외를 발생시킨다.")
+    void deletePay2() throws Exception {
+        //given
+        PayRequest payRequest = PayRequest.create(1L, seongjunId, 1L, Money.of(10000), NaturalNumber.of(3), Bank.of("우리은행", "111-111"), PayType.EQUAL_SPLIT, BaseInfo.ofEmpty());
+        when(loadPayRequestPort.loadById(1L)).thenReturn(payRequest);       // 정산 생성자는 seongjun
+
+        //when //then
+        assertThatThrownBy(() -> deletePayService.deletePay(kyungminId, 1L))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(PAY_REQUEST_CREATOR_MISMATCH.getMessage());
+    }
+}

--- a/src/test/java/space/space_spring/domain/pay/application/service/ReadBankInfoServiceTest.java
+++ b/src/test/java/space/space_spring/domain/pay/application/service/ReadBankInfoServiceTest.java
@@ -1,0 +1,75 @@
+package space.space_spring.domain.pay.application.service;
+
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import space.space_spring.domain.pay.application.port.out.LoadPayRequestPort;
+import space.space_spring.domain.pay.domain.Bank;
+import space.space_spring.domain.pay.domain.Money;
+import space.space_spring.domain.pay.domain.PayRequest;
+import space.space_spring.domain.pay.domain.PayType;
+import space.space_spring.global.common.entity.BaseInfo;
+import space.space_spring.global.util.NaturalNumber;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.when;
+
+class ReadBankInfoServiceTest {
+
+    private LoadPayRequestPort loadPayRequestPort;
+    private ReadBankInfoService readBankInfoService;
+
+    private Long seongjunId;
+
+    @BeforeEach
+    void setUp() {
+        loadPayRequestPort = Mockito.mock(LoadPayRequestPort.class);
+        readBankInfoService = new ReadBankInfoService(loadPayRequestPort);
+
+        seongjunId = 1L;
+    }
+
+    @Test
+    @DisplayName("스페이스 멤버가 과거 생성한 정산들의 은행정보를 중복을 제거하여 반환한다.")
+    void readBankInfo1() throws Exception {
+        //given
+        PayRequest payRequest1 = PayRequest.create(1L, seongjunId, 1L, Money.of(10000), NaturalNumber.of(3), Bank.of("우리은행", "111-111"), PayType.EQUAL_SPLIT, BaseInfo.ofEmpty());
+        PayRequest payRequest2 = PayRequest.create(2L, seongjunId, 2L, Money.of(20000), NaturalNumber.of(2), Bank.of("우리은행", "222-222"), PayType.EQUAL_SPLIT, BaseInfo.ofEmpty());
+        PayRequest payRequest3 = PayRequest.create(3L, seongjunId, 3L, Money.of(10000), NaturalNumber.of(5), Bank.of("국민은행", "333-333"), PayType.INDIVIDUAL, BaseInfo.ofEmpty());
+        PayRequest payRequest4 = PayRequest.create(4L, seongjunId, 4L, Money.of(10000), NaturalNumber.of(4), Bank.of("국민은행", "333-333"), PayType.INDIVIDUAL, BaseInfo.ofEmpty());
+
+        when(loadPayRequestPort.loadByPayCreatorId(seongjunId)).thenReturn(List.of(payRequest1, payRequest2, payRequest3, payRequest4));
+
+        //when
+        Set<Bank> banks = readBankInfoService.readBankInfo(seongjunId);
+
+        //then
+        assertThat(banks).hasSize(3);
+        assertThat(banks.stream())
+                .extracting("name", "accountNumber")
+                .containsExactlyInAnyOrder(
+                        tuple("우리은행", "111-111"),
+                        tuple("우리은행", "222-222"),
+                        tuple("국민은행", "333-333")
+                );
+    }
+
+    @Test
+    @DisplayName("스페이스 멤버가 과거 생성한 정산이 없는 경우 빈 Set을 반환한다.")
+    void readBankInfo2() throws Exception {
+        //given
+        when(loadPayRequestPort.loadByPayCreatorId(seongjunId)).thenReturn(List.of());          // 빈 리스트 (seongjun이 생성한 정산은 없다)
+
+        //when
+        Set<Bank> banks = readBankInfoService.readBankInfo(seongjunId);
+
+        //then
+        assertThat(banks).isEmpty();
+    }
+}

--- a/src/test/java/space/space_spring/domain/pay/application/service/ReadPayDetailServiceTest.java
+++ b/src/test/java/space/space_spring/domain/pay/application/service/ReadPayDetailServiceTest.java
@@ -19,9 +19,8 @@ import space.space_spring.global.util.NaturalNumber;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
-import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.INVALID_PAY_REQUEST_ID;
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.PAY_REQUEST_CREATOR_MISMATCH;
 
 class ReadPayDetailServiceTest {
 
@@ -105,7 +104,7 @@ class ReadPayDetailServiceTest {
         //when //then
         assertThatThrownBy(() -> readPayDetailService.readPayDetail(spaceMemberId, payRequestId))
                 .isInstanceOf(CustomException.class)
-                .hasMessage(INVALID_PAY_REQUEST_ID.getMessage());
+                .hasMessage(PAY_REQUEST_CREATOR_MISMATCH.getMessage());
     }
 
     private PayRequest createPayRequest(Long payRequestId, Long payCreatorId) {


### PR DESCRIPTION
## 📝 요약
1. 유저가 과거 생성한 정산의 은행정보 조회 api 개발
<img width="360" alt="image" src="https://github.com/user-attachments/assets/952fa796-839c-4c88-b846-b30dc811dfdb" />

2. 정산 삭제 api 개발 (soft delete 방식 사용)

3. BaseJpaEntity 에 status 변경 코드 추가

4. 정산 도메인의 jpa entity find 시에 status == active 인 jpa entity 만 찾도록 spring data jpa repository 코드 수정
  # -> 이 부분은 정산 도메인에 대해서만 수정한 상태입니다! 다른 도메인은 담당한 사람들이 수정하시면 됩니다!!

이슈 번호 : #249 

## 🔖 변경 사항

## ✅ 리뷰 요구사항
은행정보 조회 api 에서 일단 페이징 처리, 최신순 정렬 이런 처리없이 모든 정보를 일단 조회하도록 했습니다. 
추후 pm 님과 한번 논의해보겠습니다.

정산 삭제 api 의 플로우는 
영속성 adapter의 delete 메서드 호출 -> db에서 jpa entity 찾기 -> 찾은 jpa entity의 status 값을 inactive로 변경 -> 이후 트랜잭션 종료시 jpa 변경 감지 기능에 의해 db에 update 쿼리 날라감

도메인 엔티티의 status 값을 변경하고 jpa entity로 매핑하는게 아니라, 직접 jpa entity의 status 값을 변경해주도록 했습니다.
도메인 엔티티가 가지는 [생성일, 수정일, 상태] 정보는 이 정보 값이 필요할 경우 get 만 하고, 따로 값의 변경은 하지 않는 것이 도메인 엔티티끼리의 낮은 결합도 유지에 더 낫다고 생각해 삭제 플로우를 이렇게 구현했습니다.

다른 도메인 쪽의 삭제 api 시에 참고하시면 좋을것 같습니다.

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
