### PR TITLE
Feat/#275/댓글 수정 삭제

### DIFF
--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/createComment/CreateCommentController.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/createComment/CreateCommentController.java
@@ -46,7 +46,6 @@ public class CreateCommentController {
                 .commentCreatorId(spaceMemberId)
                 .content(request.getContent())
                 .isAnonymous(request.isAnonymous())
-                .attachments(request.getAttachments())
                 .build();
 
         return new BaseResponse<>(ResponseOfCreateComment.of(createCommentUseCase.createCommentFromWeb(command)));

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/createComment/RequestOfCreateAttachment.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/createComment/RequestOfCreateAttachment.java
@@ -1,0 +1,20 @@
+package space.space_spring.domain.post.adapter.in.web.createComment;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+import space.space_spring.domain.post.domain.AttachmentType;
+import space.space_spring.global.validator.EnumValidator;
+
+@Getter
+@NoArgsConstructor
+public class RequestOfCreateAttachment {
+
+    @EnumValidator(enumClass = AttachmentType.class, message = "첨부파일의 유형은 IMAGE 또는 FILE 이어야 합니다.")
+    @NotBlank(message = "첨부파일의 유형은 공백일 수 없습니다.")
+    private String valueOfAttachmentType;
+
+    @NotBlank(message = "첨부파일은 공백일 수 없습니다.")
+    private MultipartFile attachment;
+}

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/createComment/RequestOfCreateComment.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/createComment/RequestOfCreateComment.java
@@ -18,7 +18,12 @@ public class RequestOfCreateComment {
     @NotBlank(message = "댓글의 익명/비익명 여부는 공백일 수 없습니다.")
     private boolean isAnonymous;        // 작성할 댓글의 익명/비익명 여부
 
-    @Nullable
-    @Valid
-    private List<RequestOfCreateAttachment> attachments;        // 첨부 파일 리스트
+
+    /**
+     * space 2.0 v1 에서는 댓글 수정 시에 첨부파일 update 요구사항 없음
+     */
+
+//    @Nullable
+//    @Valid
+//    private List<RequestOfCreateAttachment> attachments;        // 첨부 파일 리스트
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/deleteComment/DeleteCommentController.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/deleteComment/DeleteCommentController.java
@@ -1,5 +1,7 @@
 package space.space_spring.domain.post.adapter.in.web.deleteComment;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,10 +14,16 @@ import space.space_spring.global.common.response.SuccessResponse;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Comment", description = "댓글 관련 API")
 public class DeleteCommentController {
 
     private final DeleteCommentUseCase deleteCommentUseCase;
 
+    @Operation(summary = "댓글 삭제", description = """
+            
+            스페이스 멤버가 자신이 생성한 댓글을 삭제합니다.
+            
+            """)
     @DeleteMapping("/space/{spaceId}/board/{boardId}/post/{postId}/comment/{commentId}")
     public BaseResponse<SuccessResponse> deleteComment(@JwtLoginAuth Long spaceMemberId,
                                                        @PathVariable("spaceId") Long spaceId, @PathVariable("boardId") Long boardId, @PathVariable("postId") Long postId, @PathVariable("commentId") Long commentId) {

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/deleteComment/DeleteCommentController.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/deleteComment/DeleteCommentController.java
@@ -1,0 +1,27 @@
+package space.space_spring.domain.post.adapter.in.web.deleteComment;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import space.space_spring.domain.post.application.port.in.deleteComment.DeleteCommentCommand;
+import space.space_spring.domain.post.application.port.in.deleteComment.DeleteCommentUseCase;
+import space.space_spring.global.argumentResolver.jwtLogin.JwtLoginAuth;
+import space.space_spring.global.common.response.BaseResponse;
+import space.space_spring.global.common.response.SuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+public class DeleteCommentController {
+
+    private final DeleteCommentUseCase deleteCommentUseCase;
+
+    @DeleteMapping("/space/{spaceId}/board/{boardId}/post/{postId}/comment/{commentId}")
+    public BaseResponse<SuccessResponse> deleteComment(@JwtLoginAuth Long spaceMemberId,
+                                                       @PathVariable("spaceId") Long spaceId, @PathVariable("boardId") Long boardId, @PathVariable("postId") Long postId, @PathVariable("commentId") Long commentId) {
+
+        deleteCommentUseCase.deleteComment(DeleteCommentCommand.of(spaceId, boardId, postId, commentId, spaceMemberId));
+
+        return new BaseResponse<>(new SuccessResponse(true));
+    }
+}

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/updateComment/RequestOfPreviousAttachment.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/updateComment/RequestOfPreviousAttachment.java
@@ -1,0 +1,16 @@
+package space.space_spring.domain.post.adapter.in.web.updateComment;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RequestOfPreviousAttachment {
+
+    @NotBlank(message = "삭제할 기존 첨부파일의 id값은 공백일 수 없습니다.")
+    private Long attachmentId;      // 수정할 첨부파일의 id 값
+
+    @NotBlank(message = "삭제할 기존 첨부파일의 url 값은 공백일 수 없습니다.")
+    private String attachmentUrl;
+}

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/updateComment/RequestOfUpdateAttachment.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/updateComment/RequestOfUpdateAttachment.java
@@ -1,4 +1,4 @@
-package space.space_spring.domain.post.adapter.in.web.createComment;
+package space.space_spring.domain.post.adapter.in.web.updateComment;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -9,7 +9,7 @@ import space.space_spring.global.validator.EnumValidator;
 
 @Getter
 @NoArgsConstructor
-public class RequestOfUploadAttachment {
+public class RequestOfUpdateAttachment {
 
     @EnumValidator(enumClass = AttachmentType.class, message = "첨부파일의 유형은 IMAGE 또는 FILE 이어야 합니다.")
     @NotBlank(message = "첨부파일의 유형은 공백일 수 없습니다.")

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/updateComment/RequestOfUpdateComment.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/updateComment/RequestOfUpdateComment.java
@@ -1,11 +1,8 @@
 package space.space_spring.domain.post.adapter.in.web.updateComment;
 
-import jakarta.annotation.Nullable;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import space.space_spring.domain.post.adapter.in.web.createComment.RequestOfCreateAttachment;
 
 import java.util.List;
 
@@ -19,7 +16,16 @@ public class RequestOfUpdateComment {
     @NotBlank(message = "댓글의 익명/비익명 여부는 공백일 수 없습니다.")
     private boolean isAnonymous;        // 작성할 댓글의 익명/비익명 여부
 
-    @Nullable
-    @Valid
-    private List<RequestOfCreateAttachment> attachments;        // 첨부 파일 리스트
+
+    /**
+     * space 2.0 v1 에서는 댓글 수정 시에 첨부파일 update 요구사항 없음
+     */
+
+//    @Nullable
+//    @Valid
+//    private List<RequestOfUpdateAttachment> newAttachments;        // 수정할 첨부 파일 리스트
+//
+//    @Nullable
+//    @Valid
+//    private List<RequestOfPreviousAttachment> previousAttachments;        // 삭제할 기존 첨부 파일 리스트
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/updateComment/RequestOfUpdateComment.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/updateComment/RequestOfUpdateComment.java
@@ -1,16 +1,17 @@
-package space.space_spring.domain.post.adapter.in.web.createComment;
+package space.space_spring.domain.post.adapter.in.web.updateComment;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import space.space_spring.domain.post.adapter.in.web.createComment.RequestOfCreateAttachment;
 
 import java.util.List;
 
-@NoArgsConstructor
 @Getter
-public class RequestOfCreateComment {
+@NoArgsConstructor
+public class RequestOfUpdateComment {
 
     @NotBlank(message = "댓글 작성 내용은 공백일 수 없습니다.")
     private String content;     // 작성할 댓글 내용

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/updateComment/UpdateCommentController.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/updateComment/UpdateCommentController.java
@@ -43,13 +43,13 @@ public class UpdateCommentController {
         }
 
         UpdateCommentCommand command = UpdateCommentCommand.builder()
+                .commentId(commentId)
                 .spaceId(spaceId)
                 .boardId(boardId)
                 .postId(postId)
                 .commentCreatorId(spaceMemberId)
                 .content(request.getContent())
                 .isAnonymous(request.isAnonymous())
-                .attachments(request.getAttachments())
                 .build();
 
         updateCommentUseCase.updateComment(command);

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/updateComment/UpdateCommentController.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/updateComment/UpdateCommentController.java
@@ -1,0 +1,59 @@
+package space.space_spring.domain.post.adapter.in.web.updateComment;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import space.space_spring.domain.post.adapter.in.web.createComment.ResponseOfCreateComment;
+import space.space_spring.domain.post.application.port.in.createComment.CreateCommentCommand;
+import space.space_spring.domain.post.application.port.in.updateComment.UpdateCommentCommand;
+import space.space_spring.domain.post.application.port.in.updateComment.UpdateCommentUseCase;
+import space.space_spring.global.argumentResolver.jwtLogin.JwtLoginAuth;
+import space.space_spring.global.common.response.BaseResponse;
+import space.space_spring.global.common.response.SuccessResponse;
+import space.space_spring.global.exception.CustomException;
+
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.INVALID_COMMENT_UPDATE;
+import static space.space_spring.global.util.bindingResult.BindingResultUtils.getErrorMessage;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Comment", description = "댓글 관련 API")
+public class UpdateCommentController {
+
+    private final UpdateCommentUseCase updateCommentUseCase;
+
+    @Operation(summary = "댓글 수정", description = """
+            
+            스페이스 멤버가 자신이 생성한 댓글을 수정합니다.
+            
+            """)
+    @PutMapping("/space/{spaceId}/board/{boardId}/post/{postId}/comment/{commentId}")
+    public BaseResponse<SuccessResponse> updateComment(@JwtLoginAuth Long spaceMemberId,
+                                                       @PathVariable("spaceId") Long spaceId, @PathVariable("boardId") Long boardId, @PathVariable("postId") Long postId, @PathVariable("commentId") Long commentId,
+                                                       @Validated @RequestBody RequestOfUpdateComment request, BindingResult bindingResult) {
+
+        if (bindingResult.hasErrors()) {
+            throw new CustomException(INVALID_COMMENT_UPDATE, getErrorMessage(bindingResult));
+        }
+
+        UpdateCommentCommand command = UpdateCommentCommand.builder()
+                .spaceId(spaceId)
+                .boardId(boardId)
+                .postId(postId)
+                .commentCreatorId(spaceMemberId)
+                .content(request.getContent())
+                .isAnonymous(request.isAnonymous())
+                .attachments(request.getAttachments())
+                .build();
+
+        updateCommentUseCase.updateComment(command);
+
+        return new BaseResponse<>(new SuccessResponse(true));
+    }
+}

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/attachment/AttachmentPersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/attachment/AttachmentPersistenceAdapter.java
@@ -6,9 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 import space.space_spring.domain.post.adapter.out.persistence.postBase.PostBaseJpaEntity;
 import space.space_spring.domain.post.adapter.out.persistence.postBase.PostBaseMapper;
 import space.space_spring.domain.post.adapter.out.persistence.postBase.SpringDataPostBaseRepository;
-import space.space_spring.domain.post.application.port.out.CreateAttachmentPort;
-import space.space_spring.domain.post.application.port.out.LoadAttachmentPort;
-import space.space_spring.domain.post.application.port.out.UploadAttachmentPort;
+import space.space_spring.domain.post.application.port.out.*;
 import space.space_spring.domain.post.domain.Attachment;
 import space.space_spring.domain.post.domain.AttachmentType;
 import space.space_spring.global.common.enumStatus.BaseStatusType;
@@ -26,7 +24,7 @@ import static space.space_spring.global.common.response.status.BaseExceptionResp
 
 @Repository
 @RequiredArgsConstructor
-public class AttachmentPersistenceAdapter implements LoadAttachmentPort, UploadAttachmentPort, CreateAttachmentPort {
+public class AttachmentPersistenceAdapter implements LoadAttachmentPort, UploadAttachmentPort, CreateAttachmentPort, DeleteAttachmentPort, UpdateAttachmentPort {
 
     private final SpringDataAttachmentRepository attachmentRepository;
     private final SpringDataPostBaseRepository postBaseRepository;
@@ -87,5 +85,17 @@ public class AttachmentPersistenceAdapter implements LoadAttachmentPort, UploadA
         }
 
         attachmentRepository.saveAll(attachmentJpaEntities);
+    }
+
+    @Override
+    public void deleteAllAttachments(List<String> attachmentUrls) {
+        for (String attachmentUrl : attachmentUrls) {
+            s3Uploader.deleteFileByUrl(attachmentUrl);
+        }
+    }
+
+    @Override
+    public void updateAllAttachments(List<Attachment> attachments) {
+
     }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/board/SpringDataBoardRepository.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/board/SpringDataBoardRepository.java
@@ -2,6 +2,11 @@ package space.space_spring.domain.post.adapter.out.persistence.board;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import space.space_spring.domain.post.adapter.out.persistence.board.BoardJpaEntity;
+import space.space_spring.global.common.enumStatus.BaseStatusType;
+
+import java.util.Optional;
 
 public interface SpringDataBoardRepository extends JpaRepository<BoardJpaEntity, Long> {
+
+    Optional<BoardJpaEntity> findByIdAndStatus(Long id, BaseStatusType baseStatusType);
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/CommentMapper.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/CommentMapper.java
@@ -5,6 +5,7 @@ import space.space_spring.domain.post.adapter.out.persistence.post.PostJpaEntity
 import space.space_spring.domain.post.adapter.out.persistence.postBase.PostBaseJpaEntity;
 import space.space_spring.domain.post.domain.Comment;
 import space.space_spring.domain.post.domain.Content;
+import space.space_spring.global.common.entity.BaseInfo;
 
 @Component
 public class CommentMapper {
@@ -13,15 +14,22 @@ public class CommentMapper {
         return PostCommentJpaEntity.create(postBaseJpaEntity, postJpaEntity, comment.isAnonymous());
     }
 
-    public Comment toDomainEntity(PostBaseJpaEntity postBaseJpaEntity, PostCommentJpaEntity postCommentJpaEntity) {
+    public Comment toDomainEntity(PostCommentJpaEntity jpaEntity) {
+        BaseInfo baseInfo = BaseInfo.of(
+                jpaEntity.getPostBase().getCreatedAt(),
+                jpaEntity.getPostBase().getLastModifiedAt(),
+                jpaEntity.getPostBase().getStatus()
+        );
+
         return Comment.create(
-                postBaseJpaEntity.getId(),
-                postBaseJpaEntity.getBoard().getId(),
-                postBaseJpaEntity.getDiscordId(),
-                postCommentJpaEntity.getPost().getPostBase().getId(),
-                postBaseJpaEntity.getSpaceMember().getId(),
-                Content.of(postBaseJpaEntity.getContent()),
-                postCommentJpaEntity.isAnonymous()
+                jpaEntity.getId(),
+                jpaEntity.getPostBase().getBoard().getId(),
+                jpaEntity.getPostBase().getDiscordId(),
+                jpaEntity.getPost().getId(),
+                jpaEntity.getPostBase().getSpaceMember().getId(),
+                Content.of(jpaEntity.getPostBase().getContent()),
+                jpaEntity.isAnonymous(),
+                baseInfo
         );
     }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/CommentMapper.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/CommentMapper.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import space.space_spring.domain.post.adapter.out.persistence.post.PostJpaEntity;
 import space.space_spring.domain.post.adapter.out.persistence.postBase.PostBaseJpaEntity;
 import space.space_spring.domain.post.domain.Comment;
+import space.space_spring.domain.post.domain.Content;
 
 @Component
 public class CommentMapper {
@@ -12,4 +13,15 @@ public class CommentMapper {
         return PostCommentJpaEntity.create(postBaseJpaEntity, postJpaEntity, comment.isAnonymous());
     }
 
+    public Comment toDomainEntity(PostBaseJpaEntity postBaseJpaEntity, PostCommentJpaEntity postCommentJpaEntity) {
+        return Comment.create(
+                postBaseJpaEntity.getId(),
+                postBaseJpaEntity.getBoard().getId(),
+                postBaseJpaEntity.getDiscordId(),
+                postCommentJpaEntity.getPost().getPostBase().getId(),
+                postBaseJpaEntity.getSpaceMember().getId(),
+                Content.of(postBaseJpaEntity.getContent()),
+                postCommentJpaEntity.isAnonymous()
+        );
+    }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/CommentPersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/CommentPersistenceAdapter.java
@@ -59,6 +59,16 @@ public class CommentPersistenceAdapter implements LoadCommentPort, CreateComment
 
     @Override
     public void updateComment(Comment comment) {
-        
+        PostBaseJpaEntity postBaseJpaEntity = postBaseRepository.findByIdAndStatus(comment.getTargetId(), BaseStatusType.ACTIVE)
+                .orElseThrow(() -> new CustomException(POST_BASE_NOT_FOUND));
+
+        PostJpaEntity postJpaEntity = postRepository.findByPostBaseId(comment.getTargetId())
+                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+
+        PostCommentJpaEntity postCommentJpaEntity = commentMapper.toJpaEntity(postBaseJpaEntity, postJpaEntity, comment);
+
+        // jpa entity 필드 속성 update
+        postBaseJpaEntity.changeContent(comment.getContent().getValue());
+        postCommentJpaEntity.changeAnonymous(comment.isAnonymous());
     }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/CommentPersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/CommentPersistenceAdapter.java
@@ -28,8 +28,6 @@ import static space.space_spring.global.common.response.status.BaseExceptionResp
 @RequiredArgsConstructor
 public class CommentPersistenceAdapter implements LoadCommentPort, CreateCommentPort, UpdateCommentPort, DeleteCommentPort {
 
-    private final String DELETE_COMMENT_CONTENT = "삭제된 댓글입니다.";
-
     private final SpringDataSpaceMemberRepository spaceMemberRepository;
     private final SpringDataBoardRepository boardRepository;
     private final SpringDataPostCommentRepository postCommentRepository;
@@ -94,9 +92,7 @@ public class CommentPersistenceAdapter implements LoadCommentPort, CreateComment
     }
 
     /**
-     * 댓글 삭제는
-     * 삭제할 댓글의 내용을 "삭제된 댓글입니다." 로 수정하는 방식
-     * 으로 구현
+     * 댓글 삭제는 soft delete -> 삭제된 댓글을 보여줄때는 "삭제된 댓글입니다." 라고 표시
      */
     @Override
     public void deleteComment(Long commentId) {
@@ -108,7 +104,7 @@ public class CommentPersistenceAdapter implements LoadCommentPort, CreateComment
             throw new CustomException(COMMENT_NOT_FOUND);          // 찾은 Comment가 Active 상태가 아닌 경우
         }
 
-        // jpa entity 필드 속성 update
-        postCommentJpaEntity.getPostBase().changeContent(DELETE_COMMENT_CONTENT);
+        // jpa entity 를 INACTIVE 상태로 변경
+        postCommentJpaEntity.getPostBase().updateToInactive();
     }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/PostCommentJpaEntity.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/PostCommentJpaEntity.java
@@ -14,17 +14,13 @@ import space.space_spring.domain.post.adapter.out.persistence.post.PostJpaEntity
 @Table(name = "Post_Comment")
 public class PostCommentJpaEntity {
 
-    /**
-     * Comment 테이블 하나로 합치면 수정해야함 -> 익명 여부 추가
-     */
-
     @Id
-    @GeneratedValue
     @Column(name="post_comment_id")
     @NotNull
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
+    @MapsId     // PostBaseJpaEntity의 PK 를 공유
     @JoinColumn(name = "post_base_id")
     @NotNull
     private PostBaseJpaEntity postBase;
@@ -39,6 +35,7 @@ public class PostCommentJpaEntity {
     private boolean isAnonymous;
 
     private PostCommentJpaEntity(PostBaseJpaEntity postBase, PostJpaEntity post, boolean isAnonymous) {
+        this.id = postBase.getId();     // PostBaseJpaEntity 의 식별자가 이미 있어야 한다
         this.postBase = postBase;
         this.post = post;
         this.isAnonymous = isAnonymous;

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/PostCommentJpaEntity.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/PostCommentJpaEntity.java
@@ -47,4 +47,8 @@ public class PostCommentJpaEntity {
     public static PostCommentJpaEntity create(PostBaseJpaEntity postBase, PostJpaEntity post, boolean isAnonymous) {
         return new PostCommentJpaEntity(postBase, post, isAnonymous);
     }
+
+    public void changeAnonymous(boolean isAnonymous) {
+        this.isAnonymous = isAnonymous;
+    }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/SpringDataPostCommentRepository.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/SpringDataPostCommentRepository.java
@@ -3,8 +3,10 @@ package space.space_spring.domain.post.adapter.out.persistence.comment;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import space.space_spring.global.common.enumStatus.BaseStatusType;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SpringDataPostCommentRepository extends JpaRepository<PostCommentJpaEntity, Long> {
 
@@ -13,4 +15,6 @@ public interface SpringDataPostCommentRepository extends JpaRepository<PostComme
             "WHERE pc.postBase.id IN :postIds " +
             "GROUP BY pc.postBase.id")
     List<PostCommentCount> countCommentsByPostIds(@Param("postIds") List<Long> postIds);
+
+    Optional<PostCommentJpaEntity> findByPostBaseId(Long postBaseId);
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/PostJpaEntity.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/PostJpaEntity.java
@@ -14,12 +14,12 @@ import space.space_spring.domain.post.adapter.out.persistence.postBase.PostBaseJ
 public class PostJpaEntity {
 
     @Id
-    @GeneratedValue
     @Column(name="post_id")
     @NotNull
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
+    @MapsId     // PostBaseJpaEntity의 PK 를 공유
     @JoinColumn(name = "post_base_id")
     @NotNull
     private PostBaseJpaEntity postBase;
@@ -32,6 +32,7 @@ public class PostJpaEntity {
     private Boolean isAnonymous;
 
     private PostJpaEntity(PostBaseJpaEntity postBase, String title, Boolean isAnonymous) {
+        this.id = postBase.getId();     // PostBaseJpaEntity 의 식별자가 이미 있어야 한다
         this.postBase = postBase;
         this.title = title;
         this.isAnonymous = isAnonymous;

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -59,12 +59,14 @@ public class PostPersistenceAdapter implements CreatePostPort, LoadPostPort {
     }
 
     @Override
-    public Post loadByPostBaseId(Long postBaseId) {
-        PostBaseJpaEntity postBaseJpaEntity = postBaseRepository.findByIdAndStatus(postBaseId, BaseStatusType.ACTIVE)
-                .orElseThrow(() -> new CustomException(POST_BASE_NOT_FOUND));
-
-        PostJpaEntity postJpaEntity = postRepository.findByPostBaseId(postBaseJpaEntity.getId())
+    public Post loadById(Long postId) {
+        // Post 에 해당하는 jpa entity 찾기
+        PostJpaEntity postJpaEntity = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+
+        if (!postJpaEntity.getPostBase().isActive()) {
+            throw new CustomException(POST_NOT_FOUND);          // 찾은 Post가 Active 상태가 아닌 경우
+        }
 
         return postMapper.toDomainEntity(postJpaEntity);
     }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/SpringDataPostRepository.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/SpringDataPostRepository.java
@@ -16,5 +16,4 @@ public interface SpringDataPostRepository extends JpaRepository<PostJpaEntity, L
     List<PostJpaEntity> findPostsByBoardId(@Param("boardId") Long boardId,
                                            @Param("status") BaseStatusType status);
 
-    Optional<PostJpaEntity> findByPostBaseId(Long postBaseId);
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/postBase/PostBaseJpaEntity.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/postBase/PostBaseJpaEntity.java
@@ -55,4 +55,8 @@ public class PostBaseJpaEntity extends BaseJpaEntity {
     public static PostBaseJpaEntity create(Long discordId, BoardJpaEntity board, SpaceMemberJpaEntity spaceMember, String content, LocalDateTime createdAt, LocalDateTime lastModifiedAt, BaseStatusType baseStatus) {
         return new PostBaseJpaEntity(discordId, board, spaceMember, content, createdAt, lastModifiedAt, baseStatus);
     }
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/postBase/PostBaseMapper.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/postBase/PostBaseMapper.java
@@ -3,6 +3,7 @@ package space.space_spring.domain.post.adapter.out.persistence.postBase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import space.space_spring.domain.post.adapter.out.persistence.board.BoardJpaEntity;
+import space.space_spring.domain.post.domain.Comment;
 import space.space_spring.domain.post.domain.Content;
 import space.space_spring.domain.post.domain.Post;
 import space.space_spring.domain.spaceMember.domian.SpaceMemberJpaEntity;
@@ -13,6 +14,18 @@ import space.space_spring.global.common.entity.BaseInfo;
 public class PostBaseMapper {
 
     public PostBaseJpaEntity toJpaEntity(SpaceMemberJpaEntity spaceMember, BoardJpaEntity board, Post domain) {
+        return PostBaseJpaEntity.create(
+                domain.getDiscordId(),
+                board,
+                spaceMember,
+                domain.getContent().getValue(),
+                domain.getBaseInfo().getCreatedAt(),
+                domain.getBaseInfo().getLastModifiedAt(),
+                domain.getBaseInfo().getStatus()
+        );
+    }
+
+    public PostBaseJpaEntity toJpaEntity(SpaceMemberJpaEntity spaceMember, BoardJpaEntity board, Comment domain) {
         return PostBaseJpaEntity.create(
                 domain.getDiscordId(),
                 board,

--- a/src/main/java/space/space_spring/domain/post/application/port/in/createComment/CreateAttachmentCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/createComment/CreateAttachmentCommand.java
@@ -5,18 +5,18 @@ import org.springframework.web.multipart.MultipartFile;
 import space.space_spring.domain.post.domain.AttachmentType;
 
 @Getter
-public class UploadAttachmentCommand {
+public class CreateAttachmentCommand {
 
     private AttachmentType attachmentType;
 
     private MultipartFile attachment;
 
-    private UploadAttachmentCommand(AttachmentType attachmentType, MultipartFile attachment) {
+    private CreateAttachmentCommand(AttachmentType attachmentType, MultipartFile attachment) {
         this.attachmentType = attachmentType;
         this.attachment = attachment;
     }
 
-    public static UploadAttachmentCommand of(String attachmentType, MultipartFile attachment) {
-        return new UploadAttachmentCommand(AttachmentType.valueOf(attachmentType), attachment);
+    public static CreateAttachmentCommand of(String attachmentType, MultipartFile attachment) {
+        return new CreateAttachmentCommand(AttachmentType.valueOf(attachmentType), attachment);
     }
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/in/createComment/CreateCommentCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/createComment/CreateCommentCommand.java
@@ -23,26 +23,28 @@ public class CreateCommentCommand {
 
     private boolean isAnonymous;        // 익명 댓글 여부
 
-    private List<CreateAttachmentCommand> attachmentCommands;
-
     @Builder
-    public CreateCommentCommand(Long spaceId, Long boardId, Long postId, Long commentCreatorId, String content, boolean isAnonymous, List<RequestOfCreateAttachment> attachments) {
+    public CreateCommentCommand(Long spaceId, Long boardId, Long postId, Long commentCreatorId, String content, boolean isAnonymous) {
         this.spaceId = spaceId;
         this.boardId = boardId;
         this.postId = postId;
         this.commentCreatorId = commentCreatorId;
         this.content = Content.of(content);
         this.isAnonymous = isAnonymous;
-        this.attachmentCommands = mapToInputModel(attachments);
     }
 
-    private static List<CreateAttachmentCommand> mapToInputModel(List<RequestOfCreateAttachment> attachments) {
-        return attachments.stream()
-                .map(attachment -> CreateAttachmentCommand.of(
-                        attachment.getValueOfAttachmentType(),
-                        attachment.getAttachment()))
-                .toList();
-    }
+
+    /**
+     * space 2.0 v1 에서는 댓글 수정 시에 첨부파일 update 요구사항 없음
+     */
+
+//    private static List<CreateAttachmentCommand> mapToInputModel(List<RequestOfCreateAttachment> attachments) {
+//        return attachments.stream()
+//                .map(attachment -> CreateAttachmentCommand.of(
+//                        attachment.getValueOfAttachmentType(),
+//                        attachment.getAttachment()))
+//                .toList();
+//    }
 
     public Comment toDomainEntity(Long discordId) {
         return Comment.withoutId(boardId, discordId, postId, commentCreatorId, content, isAnonymous);

--- a/src/main/java/space/space_spring/domain/post/application/port/in/deleteComment/DeleteCommentCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/deleteComment/DeleteCommentCommand.java
@@ -1,0 +1,29 @@
+package space.space_spring.domain.post.application.port.in.deleteComment;
+
+import lombok.Getter;
+
+@Getter
+public class DeleteCommentCommand {
+
+    private Long spaceId;
+
+    private Long boardId;
+
+    private Long postId;
+
+    private Long commentId;
+
+    private Long commentCreatorId;
+
+    private DeleteCommentCommand(Long spaceId, Long boardId, Long postId, Long commentId, Long commentCreatorId) {
+        this.spaceId = spaceId;
+        this.boardId = boardId;
+        this.postId = postId;
+        this.commentId = commentId;
+        this.commentCreatorId = commentCreatorId;
+    }
+
+    public static DeleteCommentCommand of(Long spaceId, Long boardId, Long postId, Long commentId, Long commentCreatorId) {
+        return new DeleteCommentCommand(spaceId, boardId, postId, commentId, commentCreatorId);
+    }
+}

--- a/src/main/java/space/space_spring/domain/post/application/port/in/deleteComment/DeleteCommentUseCase.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/deleteComment/DeleteCommentUseCase.java
@@ -1,0 +1,6 @@
+package space.space_spring.domain.post.application.port.in.deleteComment;
+
+public interface DeleteCommentUseCase {
+
+    void deleteComment(DeleteCommentCommand command);
+}

--- a/src/main/java/space/space_spring/domain/post/application/port/in/updateComment/PreviousAttachmentInfo.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/updateComment/PreviousAttachmentInfo.java
@@ -1,0 +1,20 @@
+package space.space_spring.domain.post.application.port.in.updateComment;
+
+import lombok.Getter;
+
+@Getter
+public class PreviousAttachmentInfo {
+
+    private Long attachmentId;
+
+    private String attachmentUrl;
+
+    private PreviousAttachmentInfo(Long attachmentId, String attachmentUrl) {
+        this.attachmentId = attachmentId;
+        this.attachmentUrl = attachmentUrl;
+    }
+
+    public static PreviousAttachmentInfo of(Long attachmentId, String attachmentUrl) {
+        return new PreviousAttachmentInfo(attachmentId, attachmentUrl);
+    }
+}

--- a/src/main/java/space/space_spring/domain/post/application/port/in/updateComment/UpdateAttachmentCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/updateComment/UpdateAttachmentCommand.java
@@ -1,0 +1,22 @@
+package space.space_spring.domain.post.application.port.in.updateComment;
+
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+import space.space_spring.domain.post.domain.AttachmentType;
+
+@Getter
+public class UpdateAttachmentCommand {
+
+    private AttachmentType attachmentType;
+
+    private MultipartFile attachment;
+
+    private UpdateAttachmentCommand(AttachmentType attachmentType, MultipartFile attachment) {
+        this.attachmentType = attachmentType;
+        this.attachment = attachment;
+    }
+
+    public static UpdateAttachmentCommand of(String attachmentType, MultipartFile attachment) {
+        return new UpdateAttachmentCommand(AttachmentType.valueOf(attachmentType), attachment);
+    }
+}

--- a/src/main/java/space/space_spring/domain/post/application/port/in/updateComment/UpdateCommentCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/updateComment/UpdateCommentCommand.java
@@ -2,9 +2,8 @@ package space.space_spring.domain.post.application.port.in.updateComment;
 
 import lombok.Builder;
 import lombok.Getter;
-import space.space_spring.domain.post.adapter.in.web.createComment.RequestOfCreateAttachment;
-import space.space_spring.domain.post.application.port.in.createComment.CreateAttachmentCommand;
-import space.space_spring.domain.post.domain.Comment;
+import space.space_spring.domain.post.adapter.in.web.updateComment.RequestOfPreviousAttachment;
+import space.space_spring.domain.post.adapter.in.web.updateComment.RequestOfUpdateAttachment;
 import space.space_spring.domain.post.domain.Content;
 
 import java.util.List;
@@ -26,28 +25,35 @@ public class UpdateCommentCommand {
 
     private boolean isAnonymous;        // 익명 댓글 여부
 
-    private List<CreateAttachmentCommand> attachmentCommands;
-
     @Builder
-    public UpdateCommentCommand(Long spaceId, Long boardId, Long postId, Long commentCreatorId, String content, boolean isAnonymous, List<RequestOfCreateAttachment> attachments) {
+    public UpdateCommentCommand(Long commentId, Long spaceId, Long boardId, Long postId, Long commentCreatorId, String content, boolean isAnonymous) {
+        this.commentId = commentId;
         this.spaceId = spaceId;
         this.boardId = boardId;
         this.postId = postId;
         this.commentCreatorId = commentCreatorId;
         this.content = Content.of(content);
         this.isAnonymous = isAnonymous;
-        this.attachmentCommands = mapToInputModel(attachments);
     }
 
-    private static List<CreateAttachmentCommand> mapToInputModel(List<RequestOfCreateAttachment> attachments) {
+
+    /**
+     * space 2.0 v1 에서는 댓글 수정 시에 첨부파일 update 요구사항 없음
+     */
+
+    private static List<UpdateAttachmentCommand> mapToUpdateAttachmentCommand(List<RequestOfUpdateAttachment> attachments) {
         return attachments.stream()
-                .map(attachment -> CreateAttachmentCommand.of(
+                .map(attachment -> UpdateAttachmentCommand.of(
                         attachment.getValueOfAttachmentType(),
                         attachment.getAttachment()))
                 .toList();
     }
 
-    public Comment toDomainEntity(Long discordId) {
-        return Comment.withoutId(boardId, discordId, postId, commentCreatorId, content, isAnonymous);
+    private static List<PreviousAttachmentInfo> mapToPreviousAttachmentInfo(List<RequestOfPreviousAttachment> attachments) {
+        return attachments.stream()
+                .map(attachment -> PreviousAttachmentInfo.of(
+                        attachment.getAttachmentId(),
+                        attachment.getAttachmentUrl()))
+                .toList();
     }
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/in/updateComment/UpdateCommentCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/updateComment/UpdateCommentCommand.java
@@ -1,15 +1,18 @@
-package space.space_spring.domain.post.application.port.in.createComment;
+package space.space_spring.domain.post.application.port.in.updateComment;
 
 import lombok.Builder;
 import lombok.Getter;
 import space.space_spring.domain.post.adapter.in.web.createComment.RequestOfCreateAttachment;
+import space.space_spring.domain.post.application.port.in.createComment.CreateAttachmentCommand;
 import space.space_spring.domain.post.domain.Comment;
 import space.space_spring.domain.post.domain.Content;
 
 import java.util.List;
 
 @Getter
-public class CreateCommentCommand {
+public class UpdateCommentCommand {
+
+    private Long commentId;
 
     private Long spaceId;
 
@@ -26,7 +29,7 @@ public class CreateCommentCommand {
     private List<CreateAttachmentCommand> attachmentCommands;
 
     @Builder
-    public CreateCommentCommand(Long spaceId, Long boardId, Long postId, Long commentCreatorId, String content, boolean isAnonymous, List<RequestOfCreateAttachment> attachments) {
+    public UpdateCommentCommand(Long spaceId, Long boardId, Long postId, Long commentCreatorId, String content, boolean isAnonymous, List<RequestOfCreateAttachment> attachments) {
         this.spaceId = spaceId;
         this.boardId = boardId;
         this.postId = postId;

--- a/src/main/java/space/space_spring/domain/post/application/port/in/updateComment/UpdateCommentUseCase.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/updateComment/UpdateCommentUseCase.java
@@ -1,0 +1,6 @@
+package space.space_spring.domain.post.application.port.in.updateComment;
+
+public interface UpdateCommentUseCase {
+
+    void updateComment(UpdateCommentCommand command);
+}

--- a/src/main/java/space/space_spring/domain/post/application/port/out/DeleteAttachmentPort.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/out/DeleteAttachmentPort.java
@@ -1,0 +1,8 @@
+package space.space_spring.domain.post.application.port.out;
+
+import java.util.List;
+
+public interface DeleteAttachmentPort {
+
+    void deleteAllAttachments(List<String> attachmentUrls);
+}

--- a/src/main/java/space/space_spring/domain/post/application/port/out/DeleteCommentPort.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/out/DeleteCommentPort.java
@@ -1,0 +1,6 @@
+package space.space_spring.domain.post.application.port.out;
+
+public interface DeleteCommentPort {
+
+    void deleteComment(Long commentId);
+}

--- a/src/main/java/space/space_spring/domain/post/application/port/out/LoadCommentPort.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/out/LoadCommentPort.java
@@ -8,5 +8,5 @@ import java.util.Map;
 public interface LoadCommentPort {
     Map<Long, Long> countCommentsByPostIds(List<Long> postIds);
 
-    Comment loadByPostBaseId(Long postBaseId);
+    Comment loadById(Long commentId);
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/out/LoadCommentPort.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/out/LoadCommentPort.java
@@ -1,8 +1,12 @@
 package space.space_spring.domain.post.application.port.out;
 
+import space.space_spring.domain.post.domain.Comment;
+
 import java.util.List;
 import java.util.Map;
 
 public interface LoadCommentPort {
     Map<Long, Long> countCommentsByPostIds(List<Long> postIds);
+
+    Comment loadByPostBaseId(Long postBaseId);
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/out/LoadPostPort.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/out/LoadPostPort.java
@@ -8,5 +8,5 @@ public interface LoadPostPort {
 
     List<Post> loadPostList(Long boardId);
 
-    Post loadByPostBaseId(Long postBaseId);
+    Post loadById(Long postId);
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/out/UpdateAttachmentPort.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/out/UpdateAttachmentPort.java
@@ -1,0 +1,10 @@
+package space.space_spring.domain.post.application.port.out;
+
+import space.space_spring.domain.post.domain.Attachment;
+
+import java.util.List;
+
+public interface UpdateAttachmentPort {
+
+    void updateAllAttachments(List<Attachment> attachments);
+}

--- a/src/main/java/space/space_spring/domain/post/application/port/out/UpdateCommentPort.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/out/UpdateCommentPort.java
@@ -1,0 +1,8 @@
+package space.space_spring.domain.post.application.port.out;
+
+import space.space_spring.domain.post.domain.Comment;
+
+public interface UpdateCommentPort {
+
+    void updateComment(Comment comment);
+}

--- a/src/main/java/space/space_spring/domain/post/application/service/CreateCommentService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/CreateCommentService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import space.space_spring.domain.post.application.port.in.createComment.CreateCommentCommand;
 import space.space_spring.domain.post.application.port.in.createComment.CreateCommentUseCase;
-import space.space_spring.domain.post.application.port.in.createComment.UploadAttachmentCommand;
+import space.space_spring.domain.post.application.port.in.createComment.CreateAttachmentCommand;
 import space.space_spring.domain.post.application.port.out.*;
 import space.space_spring.domain.post.domain.*;
 import space.space_spring.global.exception.CustomException;
@@ -42,8 +42,8 @@ public class CreateCommentService implements CreateCommentUseCase {
         // 3. s3에 댓글 첨부파일 upload & db에 attachment 저장
         Map<AttachmentType, List<MultipartFile>> attachmentsMap = command.getAttachmentCommands().stream()
                 .collect(Collectors.groupingBy(
-                        UploadAttachmentCommand::getAttachmentType,
-                        Collectors.mapping(UploadAttachmentCommand::getAttachment, Collectors.toUnmodifiableList())
+                        CreateAttachmentCommand::getAttachmentType,
+                        Collectors.mapping(CreateAttachmentCommand::getAttachment, Collectors.toUnmodifiableList())
                 ));
         Map<AttachmentType, List<String>> savedAttachmentUrls = uploadAttachmentPort.uploadAllAttachments(attachmentsMap, "comment");
 

--- a/src/main/java/space/space_spring/domain/post/application/service/CreateCommentService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/CreateCommentService.java
@@ -3,18 +3,11 @@ package space.space_spring.domain.post.application.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 import space.space_spring.domain.post.application.port.in.createComment.CreateCommentCommand;
 import space.space_spring.domain.post.application.port.in.createComment.CreateCommentUseCase;
-import space.space_spring.domain.post.application.port.in.createComment.CreateAttachmentCommand;
 import space.space_spring.domain.post.application.port.out.*;
 import space.space_spring.domain.post.domain.*;
 import space.space_spring.global.exception.CustomException;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.*;
 
@@ -32,7 +25,7 @@ public class CreateCommentService implements CreateCommentUseCase {
     public Long createCommentFromWeb(CreateCommentCommand command) {
         // 1. Board, Post 조회
         Board board = loadBoardPort.loadById(command.getBoardId());
-        Post post = loadPostPort.loadByPostBaseId(command.getPostId());
+        Post post = loadPostPort.loadById(command.getPostId());
 
         // 2. validation -> 게시판이 space에 속하는게 맞는지, 게시글이 게시판에 속하는게 맞는지
         validateBoardAndPost(board, post, command);

--- a/src/main/java/space/space_spring/domain/post/application/service/DeleteCommentService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/DeleteCommentService.java
@@ -2,28 +2,31 @@ package space.space_spring.domain.post.application.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import space.space_spring.domain.post.application.port.in.updateComment.UpdateCommentCommand;
-import space.space_spring.domain.post.application.port.in.updateComment.UpdateCommentUseCase;
-import space.space_spring.domain.post.application.port.out.*;
-import space.space_spring.domain.post.domain.*;
+import space.space_spring.domain.post.application.port.in.deleteComment.DeleteCommentCommand;
+import space.space_spring.domain.post.application.port.in.deleteComment.DeleteCommentUseCase;
+import space.space_spring.domain.post.application.port.out.DeleteCommentPort;
+import space.space_spring.domain.post.application.port.out.LoadBoardPort;
+import space.space_spring.domain.post.application.port.out.LoadCommentPort;
+import space.space_spring.domain.post.application.port.out.LoadPostPort;
+import space.space_spring.domain.post.domain.Board;
+import space.space_spring.domain.post.domain.Comment;
+import space.space_spring.domain.post.domain.Post;
 import space.space_spring.global.exception.CustomException;
 
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.*;
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.COMMENT_CREATOR_MISMATCH;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class UpdateCommentService implements UpdateCommentUseCase {
+public class DeleteCommentService implements DeleteCommentUseCase {
 
     private final LoadBoardPort loadBoardPort;
     private final LoadPostPort loadPostPort;
     private final LoadCommentPort loadCommentPort;
-    private final UpdateCommentPort updateCommentPort;
+    private final DeleteCommentPort deleteCommentPort;
 
     @Override
-    @Transactional
-    public void updateComment(UpdateCommentCommand command) {
+    public void deleteComment(DeleteCommentCommand command) {
         // 1. Board, Post 조회
         Board board = loadBoardPort.loadById(command.getBoardId());
         Post post = loadPostPort.loadById(command.getPostId());
@@ -32,23 +35,17 @@ public class UpdateCommentService implements UpdateCommentUseCase {
         // 2. validation
         validate(board, post, comment, command);
 
-        // 3. 댓글 update
-        comment.changeContent(command.getContent());
-        comment.changeAnonymous(command.isAnonymous());
-        updateCommentPort.updateComment(comment);
+        // 3. 댓글 삭제
+        deleteCommentPort.deleteComment(command.getCommentId());
     }
 
-    private void validate(Board board, Post post, Comment comment, UpdateCommentCommand command) {
+    private void validate(Board board, Post post, Comment comment, DeleteCommentCommand command) {
         if (!board.isInSpace(command.getSpaceId())) {       // board가 스페이스에 속하는지 검증
             throw new CustomException(BOARD_IS_NOT_IN_SPACE);
         }
 
         if (!post.isInBoard(board.getId())) {       // post가 보드에 속하는지 검증
             throw new CustomException(POST_IS_NOT_IN_BOARD);
-        }
-
-        if (board.getBoardType() != BoardType.QUESTION && command.isAnonymous()) {      // 질문 게시글이 아닌데 댓글 작성자가 익명이라면
-            throw new CustomException(CAN_NOT_BE_ANONYMOUS);
         }
 
         if (!comment.isCommentCreator(command.getCommentCreatorId())) {     // 댓글 작성자가 본인이 맞는지

--- a/src/main/java/space/space_spring/domain/post/application/service/UpdateCommentService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/UpdateCommentService.java
@@ -1,0 +1,17 @@
+package space.space_spring.domain.post.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import space.space_spring.domain.post.application.port.in.updateComment.UpdateCommentCommand;
+import space.space_spring.domain.post.application.port.in.updateComment.UpdateCommentUseCase;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateCommentService implements UpdateCommentUseCase {
+
+
+    @Override
+    public void updateComment(UpdateCommentCommand command) {
+
+    }
+}

--- a/src/main/java/space/space_spring/domain/post/application/service/UpdateCommentService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/UpdateCommentService.java
@@ -3,21 +3,11 @@ package space.space_spring.domain.post.application.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-import space.space_spring.domain.post.application.port.in.createComment.CreateAttachmentCommand;
-import space.space_spring.domain.post.application.port.in.createComment.CreateCommentCommand;
-import space.space_spring.domain.post.application.port.in.updateComment.PreviousAttachmentInfo;
-import space.space_spring.domain.post.application.port.in.updateComment.UpdateAttachmentCommand;
 import space.space_spring.domain.post.application.port.in.updateComment.UpdateCommentCommand;
 import space.space_spring.domain.post.application.port.in.updateComment.UpdateCommentUseCase;
 import space.space_spring.domain.post.application.port.out.*;
 import space.space_spring.domain.post.domain.*;
 import space.space_spring.global.exception.CustomException;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.*;
 
@@ -36,8 +26,8 @@ public class UpdateCommentService implements UpdateCommentUseCase {
     public void updateComment(UpdateCommentCommand command) {
         // 1. Board, Post 조회
         Board board = loadBoardPort.loadById(command.getBoardId());
-        Post post = loadPostPort.loadByPostBaseId(command.getPostId());
-        Comment comment = loadCommentPort.loadByPostBaseId(command.getPostId());
+        Post post = loadPostPort.loadById(command.getPostId());
+        Comment comment = loadCommentPort.loadById(command.getCommentId());
 
         // 2. validation
         validate(board, post, comment, command);

--- a/src/main/java/space/space_spring/domain/post/application/service/UpdateCommentService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/UpdateCommentService.java
@@ -2,16 +2,67 @@ package space.space_spring.domain.post.application.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import space.space_spring.domain.post.application.port.in.createComment.CreateAttachmentCommand;
+import space.space_spring.domain.post.application.port.in.createComment.CreateCommentCommand;
+import space.space_spring.domain.post.application.port.in.updateComment.PreviousAttachmentInfo;
+import space.space_spring.domain.post.application.port.in.updateComment.UpdateAttachmentCommand;
 import space.space_spring.domain.post.application.port.in.updateComment.UpdateCommentCommand;
 import space.space_spring.domain.post.application.port.in.updateComment.UpdateCommentUseCase;
+import space.space_spring.domain.post.application.port.out.*;
+import space.space_spring.domain.post.domain.*;
+import space.space_spring.global.exception.CustomException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.*;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UpdateCommentService implements UpdateCommentUseCase {
 
+    private final LoadBoardPort loadBoardPort;
+    private final LoadPostPort loadPostPort;
+    private final LoadCommentPort loadCommentPort;
+    private final UpdateCommentPort updateCommentPort;
 
     @Override
+    @Transactional
     public void updateComment(UpdateCommentCommand command) {
+        // 1. Board, Post 조회
+        Board board = loadBoardPort.loadById(command.getBoardId());
+        Post post = loadPostPort.loadByPostBaseId(command.getPostId());
+        Comment comment = loadCommentPort.loadByPostBaseId(command.getPostId());
 
+        // 2. validation
+        validate(board, post, comment, command);
+
+        // 3. 게시글 update
+        comment.changeContent(command.getContent());
+        comment.changeAnonymous(command.isAnonymous());
+        updateCommentPort.updateComment(comment);
+    }
+
+    private void validate(Board board, Post post, Comment comment, UpdateCommentCommand command) {
+        if (!board.isInSpace(command.getSpaceId())) {       // board가 스페이스에 속하는지 검증
+            throw new CustomException(BOARD_IS_NOT_IN_SPACE);
+        }
+
+        if (!post.isInBoard(board.getId())) {       // post가 보드에 속하는지 검증
+            throw new CustomException(POST_IS_NOT_IN_BOARD);
+        }
+
+        if (board.getBoardType() != BoardType.QUESTION && command.isAnonymous()) {      // 질문 게시글이 아닌데 댓글 작성자가 익명이라면
+            throw new CustomException(CAN_NOT_BE_ANONYMOUS);
+        }
+
+        if (!comment.isCommentCreator(command.getCommentCreatorId())) {     // 댓글 작성자가 본인이 맞는지
+            throw new CustomException(COMMENT_CREATOR_MISMATCH);
+        }
     }
 }

--- a/src/main/java/space/space_spring/domain/post/domain/Comment.java
+++ b/src/main/java/space/space_spring/domain/post/domain/Comment.java
@@ -11,29 +11,41 @@ public class Comment {
 
     private Long discordId;
 
-    private Long targetId; // post, question의 postBaseId
+    private Long targetId; // post의 postBaseId
 
-    private Long spaceMemberId;
+    private Long commentCreatorId;
 
     private Content content;
 
     private boolean isAnonymous;
 
-    private Comment(Long id, Long boardId, Long discordId, Long targetId, Long spaceMemberId, Content content, boolean isAnonymous) {
+    private Comment(Long id, Long boardId, Long discordId, Long targetId, Long commentCreatorId, Content content, boolean isAnonymous) {
         this.id = id;
         this.boardId = boardId;
         this.discordId = discordId;
         this.targetId = targetId;
-        this.spaceMemberId = spaceMemberId;
+        this.commentCreatorId = commentCreatorId;
         this.content = content;
         this.isAnonymous = isAnonymous;
     }
 
-    public static Comment create(Long id, Long boardId, Long discordId, Long targetId, Long spaceMemberId, Content content, boolean isAnonymous) {
-        return new Comment(id, boardId, discordId, targetId, spaceMemberId, content, isAnonymous);
+    public static Comment create(Long id, Long boardId, Long discordId, Long targetId, Long commentCreatorId, Content content, boolean isAnonymous) {
+        return new Comment(id, boardId, discordId, targetId, commentCreatorId, content, isAnonymous);
     }
 
-    public static Comment withoutId(Long boardId, Long discordId, Long targetId, Long spaceMemberId, Content content, boolean isAnonymous) {
-        return new Comment(null, boardId, discordId, targetId, spaceMemberId, content, isAnonymous);
+    public static Comment withoutId(Long boardId, Long discordId, Long targetId, Long commentCreatorId, Content content, boolean isAnonymous) {
+        return new Comment(null, boardId, discordId, targetId, commentCreatorId, content, isAnonymous);
+    }
+
+    public boolean isCommentCreator(Long spaceMemberId) {
+        return commentCreatorId.equals(spaceMemberId);
+    }
+
+    public void changeContent(Content content) {
+        this.content = content;
+    }
+
+    public void changeAnonymous(boolean isAnonymous) {
+        this.isAnonymous = isAnonymous;
     }
 }

--- a/src/main/java/space/space_spring/domain/post/domain/Comment.java
+++ b/src/main/java/space/space_spring/domain/post/domain/Comment.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public class Comment {
 
-    private Long id; // postBaseId
+    private Long id; // comment의 postBaseId
 
     private Long boardId;
 

--- a/src/main/java/space/space_spring/domain/post/domain/Comment.java
+++ b/src/main/java/space/space_spring/domain/post/domain/Comment.java
@@ -1,17 +1,18 @@
 package space.space_spring.domain.post.domain;
 
 import lombok.Getter;
+import space.space_spring.global.common.entity.BaseInfo;
 
 @Getter
 public class Comment {
 
-    private Long id; // comment의 postBaseId
+    private Long id;
 
     private Long boardId;
 
     private Long discordId;
 
-    private Long targetId; // post의 postBaseId
+    private Long postId;
 
     private Long commentCreatorId;
 
@@ -19,22 +20,28 @@ public class Comment {
 
     private boolean isAnonymous;
 
-    private Comment(Long id, Long boardId, Long discordId, Long targetId, Long commentCreatorId, Content content, boolean isAnonymous) {
+    private BaseInfo baseInfo;
+
+    private Comment(Long id, Long boardId, Long discordId, Long postId, Long commentCreatorId, Content content, boolean isAnonymous, BaseInfo baseInfo) {
         this.id = id;
         this.boardId = boardId;
         this.discordId = discordId;
-        this.targetId = targetId;
+        this.postId = postId;
         this.commentCreatorId = commentCreatorId;
         this.content = content;
         this.isAnonymous = isAnonymous;
+        this.baseInfo = baseInfo;
     }
 
-    public static Comment create(Long id, Long boardId, Long discordId, Long targetId, Long commentCreatorId, Content content, boolean isAnonymous) {
-        return new Comment(id, boardId, discordId, targetId, commentCreatorId, content, isAnonymous);
+    public static Comment create(Long id, Long boardId, Long discordId, Long postId, Long commentCreatorId, Content content, boolean isAnonymous, BaseInfo baseInfo) {
+        return new Comment(id, boardId, discordId, postId, commentCreatorId, content, isAnonymous, baseInfo);
     }
 
-    public static Comment withoutId(Long boardId, Long discordId, Long targetId, Long commentCreatorId, Content content, boolean isAnonymous) {
-        return new Comment(null, boardId, discordId, targetId, commentCreatorId, content, isAnonymous);
+    /**
+     * 처음 Domain Entity 생성 시 사용하는 정적 펙토리 메서드
+     */
+    public static Comment withoutId(Long boardId, Long discordId, Long postId, Long commentCreatorId, Content content, boolean isAnonymous) {
+        return new Comment(null, boardId, discordId, postId, commentCreatorId, content, isAnonymous, BaseInfo.ofEmpty());
     }
 
     public boolean isCommentCreator(Long spaceMemberId) {

--- a/src/main/java/space/space_spring/global/common/entity/BaseJpaEntity.java
+++ b/src/main/java/space/space_spring/global/common/entity/BaseJpaEntity.java
@@ -57,4 +57,8 @@ public abstract class BaseJpaEntity {
     public void updateToActive() { this.status = BaseStatusType.ACTIVE; }
 
     public void updateToInactive() { this.status = BaseStatusType.INACTIVE; }
+
+    public boolean isActive() {
+        return this.status == BaseStatusType.ACTIVE;
+    }
 }

--- a/src/main/java/space/space_spring/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/global/common/response/status/BaseExceptionResponseStatus.java
@@ -105,7 +105,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     POST_IS_NOT_IN_SPACE(11002, HttpStatus.NOT_FOUND, "해당 게시글은 이 스페이스에 속하지 않습니다."),
     ALREADY_LIKED_THE_POST(11003, HttpStatus.BAD_REQUEST, "해당 게시글에 이미 좋아요를 눌렀습니다."),
     NOT_LIKED_THE_POST_YET(11003, HttpStatus.BAD_REQUEST, "유저가 해당 게시글에 좋아요를 누르지 않았습니다."),
-    COMMENT_NOT_EXIST(11004, HttpStatus.NOT_FOUND, "존재하지 않는 댓글 id입니다."),
+    COMMENT_NOT_FOUND(11004, HttpStatus.NOT_FOUND, "존재하지 않는 댓글 id입니다."),
     ALREADY_LIKED_THE_COMMENT(11005, HttpStatus.BAD_REQUEST, "해당 댓글에 이미 좋아요를 눌렀습니다."),
     NOT_LIKED_THE_COMMENT_YET(11006, HttpStatus.BAD_REQUEST, "유저가 해당 댓글에 좋아요를 누르지 않았습니다."),
     TARGET_ID_MISSING(11007, HttpStatus.BAD_REQUEST, "대댓글 작성 시 targetId가 필요합니다"),
@@ -117,6 +117,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     POST_IS_NOT_IN_BOARD(11013, HttpStatus.NOT_FOUND, "현재 게시판에는 해당 게시글이 존재하지 않습니다."),
     CAN_NOT_BE_ANONYMOUS(11014, HttpStatus.BAD_REQUEST, "해당 글은 익명으로 작성할 수 없습니다."),
     INVALID_COMMENT_UPDATE(11015, HttpStatus.BAD_REQUEST, "댓글 수정 요청에서 잘못된 값이 존재합니다."),
+    COMMENT_CREATOR_MISMATCH(11016, HttpStatus.BAD_REQUEST, "댓글 생성자가 본인과 일치하지 않습니다."),
+
 
     /**
      * 12000 : Pay 오류

--- a/src/main/java/space/space_spring/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/global/common/response/status/BaseExceptionResponseStatus.java
@@ -116,6 +116,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     BOARD_IS_NOT_IN_SPACE(11012, HttpStatus.NOT_FOUND, "현재 스페이스에는 해당 게시판이 존재하지 않습니다."),
     POST_IS_NOT_IN_BOARD(11013, HttpStatus.NOT_FOUND, "현재 게시판에는 해당 게시글이 존재하지 않습니다."),
     CAN_NOT_BE_ANONYMOUS(11014, HttpStatus.BAD_REQUEST, "해당 글은 익명으로 작성할 수 없습니다."),
+    INVALID_COMMENT_UPDATE(11015, HttpStatus.BAD_REQUEST, "댓글 수정 요청에서 잘못된 값이 존재합니다."),
 
     /**
      * 12000 : Pay 오류

--- a/src/main/java/space/space_spring/global/util/S3Uploader.java
+++ b/src/main/java/space/space_spring/global/util/S3Uploader.java
@@ -17,6 +17,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.UUID;
@@ -34,14 +36,44 @@ public class S3Uploader {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    //MultipartFile을 전달 받아 File로 전환 후 S3 업로드
-//    public String uploadFile(MultipartFile multipartFile, String dirName) throws IOException{// dirName의 디렉토리가 S3 Bucket 내부에 생성됨
-//
-//        File uploadFile = convert(multipartFile).orElseThrow(()-> new IllegalArgumentException("MultipartFile -> File 전환 실패"));
-//        //System.out.p
-//        // print("error: multipart file input. cant control");
-//        return upload(uploadFile,dirName);
-//    }
+    // MultipartFile이 지원하는 이미지 파일 형식인지 검증
+    public boolean isImageFile(MultipartFile file) {
+        String fileName = file.getOriginalFilename();
+        String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
+
+        log.info("extension : {}", extension);
+
+        return AllowedImageFileExtensions.contains(extension);
+    }
+
+    // MultipartFile이 지원하는 문서 파일 형식인지 검증
+    public boolean isDocumentFile(MultipartFile file) {
+        String fileName = file.getOriginalFilename();
+        String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
+
+        log.info("extension : {}", extension);
+
+        return AllowedDocumentFileExtensions.contains(extension);
+    }
+
+    public void deleteFileByUrl(String fileUrl) {
+        // 예시: https://bucket.s3.amazonaws.com/dirName/profile.xxx
+        // S3 URL 형식에 따라 객체 키를 추출하는 로직
+        try {
+            URL url = new URL(fileUrl);
+            String path = url.getPath();        // 예시: /dirName/profile.xxx
+            String key = path.startsWith("/") ? path.substring(1) : path;       // path에서 key 파싱
+
+            if (amazonS3Client.doesObjectExist(bucket, key)) {
+                amazonS3Client.deleteObject(bucket, key);
+                log.info("S3에서 파일 삭제됨 : {}", key);
+            } else {
+                log.warn("삭제할 파일이 존재하지 않음 : {}", key);
+            }
+        } catch (MalformedURLException e) {
+            log.error("URL 파싱 오류 : {}", fileUrl, e);
+        }
+    }
 
     // File에 저장하지 않고 Memory에서 변환 시행
     public String upload(MultipartFile file, String dirName) throws IOException{
@@ -69,25 +101,20 @@ public class S3Uploader {
         return dirName + "/" +UUID.randomUUID().toString() + fileExtension;
     }
 
-//    public String upload(File uploadFile, String dirName){
-//        String fileName = dirName+"/"+uploadFile.getName();
-//        String uploadImageUrl = putS3(uploadFile,fileName);
-//
-//        removeNewFile(uploadFile);// convert()함수로 인해서 로컬에 생성된 File 삭제 (MultipartFile -> File 전환 하며 로컬에 파일 생성됨)
-//        return uploadImageUrl;
-//    }
     // 업로드하기
     private String putS3(File uploadFile, String fileName){
         amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
                 .withCannedAcl(CannedAccessControlList.PublicRead));
         return amazonS3Client.getUrl(bucket, fileName).toString();
     }
+
     private String putS3(String fileName,InputStream uploadFile, ObjectMetadata metadata) {
         amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile,metadata)
                 .withCannedAcl(CannedAccessControlList.PublicRead));
         return amazonS3Client.getUrl(bucket, fileName).toString();
     }
-        // 이미지 지우기
+
+    // 이미지 지우기
     private void removeNewFile(File targetFile) {
         if (targetFile.delete()) {
             log.info("File delete success");
@@ -95,6 +122,24 @@ public class S3Uploader {
         }
         log.info("File delete fail");
     }
+
+    //MultipartFile을 전달 받아 File로 전환 후 S3 업로드
+//    public String uploadFile(MultipartFile multipartFile, String dirName) throws IOException{// dirName의 디렉토리가 S3 Bucket 내부에 생성됨
+//
+//        File uploadFile = convert(multipartFile).orElseThrow(()-> new IllegalArgumentException("MultipartFile -> File 전환 실패"));
+//        //System.out.p
+//        // print("error: multipart file input. cant control");
+//        return upload(uploadFile,dirName);
+//    }
+
+//    public String upload(File uploadFile, String dirName){
+//        String fileName = dirName+"/"+uploadFile.getName();
+//        String uploadImageUrl = putS3(uploadFile,fileName);
+//
+//        removeNewFile(uploadFile);// convert()함수로 인해서 로컬에 생성된 File 삭제 (MultipartFile -> File 전환 하며 로컬에 파일 생성됨)
+//        return uploadImageUrl;
+//    }
+
     private Optional<File> convert(MultipartFile file) throws  IOException {
         File convertFile = new File(file.getOriginalFilename()); // 업로드한 파일의 이름
         if(convertFile.createNewFile()) {
@@ -104,26 +149,6 @@ public class S3Uploader {
             return Optional.of(convertFile);
         }
         return Optional.empty();
-    }
-
-    // MultipartFile이 지원하는 이미지 파일 형식인지 검증
-    public boolean isImageFile(MultipartFile file) {
-        String fileName = file.getOriginalFilename();
-        String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
-
-        log.info("extension : {}", extension);
-
-        return AllowedImageFileExtensions.contains(extension);
-    }
-
-    // MultipartFile이 지원하는 문서 파일 형식인지 검증
-    public boolean isDocumentFile(MultipartFile file) {
-        String fileName = file.getOriginalFilename();
-        String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
-
-        log.info("extension : {}", extension);
-
-        return AllowedDocumentFileExtensions.contains(extension);
     }
 
     public String uploadBase64File(String base64File, String dirName, String fileName) throws IOException {


### PR DESCRIPTION
## 📝 요약
1. 댓글 수정 api 개발
  -> 댓글의 내용, 댓글의 익명여부 를 수정할 수 있습니다
  -> 자신이 작성한 댓글만 수정할 수 있습니다

2. 댓글 삭제 api 개발
  -> 댓글의 내용을 "삭제된 댓글입니다." 라고 수정합니다.
  -> 마찬가지로 자신이 작성한 댓글만 삭제할 수 있습니다

3. 댓글 생성 api 에서 첨부파일 업로드 하는 코드 삭제
  -> 스페이스 웹에서의 댓글 생성 시에는 첨부파일을 업로드 하는 기능은 현재 없는 것으로 확인됐습니다

4. AWS S3 에 업로드한 파일 삭제하는 코드 추가
  -> S3에 업로드한 파일을 삭제하는 코드를 추가했습니다
  -> 이때 S3에서 파일을 찾을 수 있도록 업로드 시에 입력한 dirName 을 파라미터로 넘겨줘야 합니다. 
  -> 댓글 수정 시에 업로드한 기존의 첨부파일을 삭제하고, 새로운 첨부파일을 업로드하기 위해 개밣하였지만, 댓글에는 첨부파일을 고려하지 않기로 해서 현재는 미사용인 코드입니다
  -> 게시글 수정 api 개발 시에 사용하면 됩니다! @arkchive 
  
5. PostBase의 PK 를 Post, Comment 의 PK로도 사용
  -> 기존에는 request, response의 postId, commentId 로 postBaseId 를 넘겨야하는데, 이 부분에 직관적이지 않고 휴면에러의 가능성이 있어 수정했습니다.
  -> 다만 Post, Comment jpa entity에 @GenerateValue 를 없앴으므로 PostBase jpa entity를 먼저 생성한 후, postBaseId를 얻어서 Post or Comment jpa entity를 생성해야 합니다
  관련 레퍼런스 : https://achieve-dev.tistory.com/64

이슈 번호 : #275 

## 🔖 변경 사항

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
