### PR TITLE
Feat/#261/게시글 통합 생성

### DIFF
--- a/src/main/java/space/space_spring/domain/discord/application/port/in/createPost/CreatePostInDiscordCommand.java
+++ b/src/main/java/space/space_spring/domain/discord/application/port/in/createPost/CreatePostInDiscordCommand.java
@@ -2,7 +2,7 @@ package space.space_spring.domain.discord.application.port.in.createPost;
 
 import lombok.Builder;
 import lombok.Getter;
-import space.space_spring.domain.post.application.port.in.createPost.AttachmentOfCreateCommand;
+import space.space_spring.domain.post.application.port.in.createPost.AttachmentInDiscordCommand;
 import space.space_spring.domain.post.domain.Content;
 
 import java.util.List;
@@ -10,22 +10,28 @@ import java.util.List;
 @Getter
 public class CreatePostInDiscordCommand {
 
-    private Long postCreatorId;
+    private Long spaceId;
 
     private Long boardId;
+
+    private Long postCreatorId;
 
     private String title;
 
     private Content content;
 
-    private List<AttachmentOfCreateCommand> attachments;
+    private List<AttachmentInDiscordCommand> attachments;
+
+    private Boolean isAnonymous;
 
     @Builder
-    public CreatePostInDiscordCommand(Long postCreatorId, Long boardId, String title, Content content, List<AttachmentOfCreateCommand> attachments) {
-        this.postCreatorId = postCreatorId;
+    public CreatePostInDiscordCommand(Long spaceId, Long boardId, Long postCreatorId, String title, Content content, List<AttachmentInDiscordCommand> attachments, Boolean isAnonymous) {
+        this.spaceId = spaceId;
         this.boardId = boardId;
+        this.postCreatorId = postCreatorId;
         this.title = title;
         this.content = content;
         this.attachments = attachments;
+        this.isAnonymous = isAnonymous;
     }
 }

--- a/src/main/java/space/space_spring/domain/discord/application/port/out/createPost/CreatePostMessageCommand.java
+++ b/src/main/java/space/space_spring/domain/discord/application/port/out/createPost/CreatePostMessageCommand.java
@@ -2,7 +2,7 @@ package space.space_spring.domain.discord.application.port.out.createPost;
 
 import lombok.Builder;
 import lombok.Getter;
-import space.space_spring.domain.post.application.port.in.createPost.AttachmentOfCreateCommand;
+import space.space_spring.domain.post.application.port.in.createPost.AttachmentInDiscordCommand;
 import space.space_spring.domain.post.domain.Content;
 
 import java.util.List;
@@ -10,23 +10,29 @@ import java.util.List;
 @Getter
 public class CreatePostMessageCommand {
 
-    private Long postCreatorDiscordId;
+    private Long spaceId;
 
     private Long boardDiscordId;
+
+    private Long postCreatorDiscordId;
 
     private String title;
 
     private Content content;
 
-    private List<AttachmentOfCreateCommand> attachments;
+    private List<AttachmentInDiscordCommand> attachments;
+
+    private Boolean isAnonymous;
 
     @Builder
-    public CreatePostMessageCommand(Long postCreatorDiscordId, Long boardDiscordId, String title, Content content, List<AttachmentOfCreateCommand> attachments) {
-        this.postCreatorDiscordId = postCreatorDiscordId;
+    public CreatePostMessageCommand(Long spaceId, Long boardDiscordId, Long postCreatorDiscordId, String title, Content content, List<AttachmentInDiscordCommand> attachments, Boolean isAnonymous) {
+        this.spaceId = spaceId;
         this.boardDiscordId = boardDiscordId;
+        this.postCreatorDiscordId = postCreatorDiscordId;
         this.title = title;
         this.content = content;
         this.attachments = attachments;
+        this.isAnonymous = isAnonymous;
     }
 
 }

--- a/src/main/java/space/space_spring/domain/discord/application/service/CreatePostInDiscordService.java
+++ b/src/main/java/space/space_spring/domain/discord/application/service/CreatePostInDiscordService.java
@@ -38,11 +38,13 @@ public class CreatePostInDiscordService implements CreatePostInDiscordUseCase {
         Long boardDiscordId = board.getDiscordId();
 
         return CreatePostMessageCommand.builder()
-                .postCreatorDiscordId(postCreatorDiscordId)
+                .spaceId(command.getSpaceId())
                 .boardDiscordId(boardDiscordId)
+                .postCreatorDiscordId(postCreatorDiscordId)
                 .title(command.getTitle())
                 .content(command.getContent())
                 .attachments(command.getAttachments())
+                .isAnonymous(command.getIsAnonymous())
                 .build();
     }
 

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/createPost/AttachmentOfCreate.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/createPost/AttachmentOfCreate.java
@@ -3,6 +3,7 @@ package space.space_spring.domain.post.adapter.in.web.createPost;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 import space.space_spring.domain.post.domain.AttachmentType;
 import space.space_spring.global.common.validation.SelfValidating;
 import space.space_spring.global.validator.EnumValidator;
@@ -11,15 +12,11 @@ import space.space_spring.global.validator.EnumValidator;
 @NoArgsConstructor
 public class AttachmentOfCreate extends SelfValidating<AttachmentOfCreate> {
 
-    @EnumValidator(enumClass = AttachmentType.class, message = "attachmentType은 IMAGE 또는 FILE 이어야 합니다.")
+    @EnumValidator(enumClass = AttachmentType.class, message = "첨부파일의 유형은 IMAGE 또는 FILE 이어야 합니다.")
+    @NotBlank(message = "첨부파일의 유형은 공백일 수 없습니다.")
     private String valueOfAttachmentType;
 
-    @NotBlank(message = "attachmentUrl은 필수입니다.")
-    private String attachmentUrl;
+    @NotBlank(message = "첨부파일은 공백일 수 없습니다.")
+    private MultipartFile attachment;
 
-    public AttachmentOfCreate(String valueOfAttachmentType, String attachmentUrl) {
-        this.valueOfAttachmentType = valueOfAttachmentType;
-        this.attachmentUrl = attachmentUrl;
-        this.validateSelf();
-    }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/createPost/CreatePostController.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/createPost/CreatePostController.java
@@ -39,15 +39,16 @@ public class CreatePostController {
         }
 
         CreatePostCommand command = CreatePostCommand.builder()
-                .postCreatorId(spaceMemberId)
+                .spaceId(spaceId)
                 .boardId(boardId)
+                .postCreatorId(spaceMemberId)
                 .title(request.getTitle())
                 .content(request.getContent())
                 .attachments(request.getAttachments())
                 .isAnonymous(request.getIsAnonymous())
                 .build();
 
-        return new BaseResponse<>(createPostUseCase.createPostFromWeb(spaceMemberId, spaceId, command));
+        return new BaseResponse<>(createPostUseCase.createPostFromWeb(command));
 
     }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/createPost/CreatePostController.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/createPost/CreatePostController.java
@@ -27,7 +27,7 @@ public class CreatePostController {
             스페이스 멤버가 게시글(=일반 게시글, 질문, Tip)을 생성합니다.
             
             """)
-    @PostMapping("/space/{spaceId}/board/{boardId}/create")
+    @PostMapping("/space/{spaceId}/board/{boardId}/post")
     public BaseResponse<Long> createPost(
             @JwtLoginAuth Long spaceMemberId,
             @PathVariable Long spaceId,

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/createPost/CreatePostController.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/createPost/CreatePostController.java
@@ -1,5 +1,7 @@
 package space.space_spring.domain.post.adapter.in.web.createPost;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
@@ -15,10 +17,16 @@ import static space.space_spring.global.util.bindingResult.BindingResultUtils.ge
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Post", description = "게시글 관련 API")
 public class CreatePostController {
 
     private final CreatePostUseCase createPostUseCase;
 
+    @Operation(summary = "게시글 생성", description = """
+            
+            스페이스 멤버가 게시글(=일반 게시글, 질문, Tip)을 생성합니다.
+            
+            """)
     @PostMapping("/space/{spaceId}/board/{boardId}/create")
     public BaseResponse<Long> createPost(
             @JwtLoginAuth Long spaceMemberId,

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/createPost/RequestOfCreatePost.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/createPost/RequestOfCreatePost.java
@@ -13,16 +13,17 @@ import java.util.List;
 @NoArgsConstructor
 public class RequestOfCreatePost extends SelfValidating<RequestOfCreatePost> {
 
-    @NotBlank(message = "title은 공백일 수 없습니다.")
+    @NotBlank(message = "게시글 제목은 공백일 수 없습니다.")
     private String title;
 
-    @NotBlank(message = "content는 공백일 수 없습니다.")
+    @NotBlank(message = "게시글 내용은 공백일 수 없습니다.")
     private String content;
 
     @Valid
+    @Nullable
     private List<AttachmentOfCreate> attachments;
 
-
+    @NotBlank(message = "게시글의 익명/비익명 여부는 공백일 수 없습니다.")
     private Boolean isAnonymous; // 질문일 경우만 사용
 
     public RequestOfCreatePost(String title, String content, List<AttachmentOfCreate> attachments, Boolean isAnonymous) {

--- a/src/main/java/space/space_spring/domain/post/application/port/in/createPost/AttachmentInDiscordCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/createPost/AttachmentInDiscordCommand.java
@@ -1,0 +1,21 @@
+package space.space_spring.domain.post.application.port.in.createPost;
+
+import lombok.Getter;
+import space.space_spring.domain.post.domain.AttachmentType;
+
+@Getter
+public class AttachmentInDiscordCommand {
+
+    private AttachmentType attachmentType;
+
+    private String attachmentUrl;
+
+    private AttachmentInDiscordCommand(AttachmentType attachmentType, String attachmentUrl) {
+        this.attachmentType = attachmentType;
+        this.attachmentUrl = attachmentUrl;
+    }
+
+    public static AttachmentInDiscordCommand create(String valueOfAttachmentType, String attachmentUrl) {
+        return new AttachmentInDiscordCommand(AttachmentType.fromString(valueOfAttachmentType), attachmentUrl);
+    }
+}

--- a/src/main/java/space/space_spring/domain/post/application/port/in/createPost/AttachmentOfCreateCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/createPost/AttachmentOfCreateCommand.java
@@ -1,6 +1,7 @@
 package space.space_spring.domain.post.application.port.in.createPost;
 
 import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
 import space.space_spring.domain.post.domain.AttachmentType;
 
 @Getter
@@ -8,14 +9,14 @@ public class AttachmentOfCreateCommand {
 
     private AttachmentType attachmentType;
 
-    private String attachmentUrl;
+    private MultipartFile attachment;
 
-    private AttachmentOfCreateCommand(AttachmentType attachmentType, String attachmentUrl) {
+    private AttachmentOfCreateCommand(AttachmentType attachmentType, MultipartFile attachment) {
         this.attachmentType = attachmentType;
-        this.attachmentUrl = attachmentUrl;
+        this.attachment = attachment;
     }
 
-    public static AttachmentOfCreateCommand create(String valueOfAttachmentType, String attachmentUrl) {
-        return new AttachmentOfCreateCommand(AttachmentType.fromString(valueOfAttachmentType), attachmentUrl);
+    public static AttachmentOfCreateCommand create(String valueOfAttachmentType, MultipartFile attachment) {
+        return new AttachmentOfCreateCommand(AttachmentType.fromString(valueOfAttachmentType), attachment);
     }
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/in/createPost/CreatePostCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/createPost/CreatePostCommand.java
@@ -12,9 +12,11 @@ import java.util.List;
 @Getter
 public class CreatePostCommand {
 
-    private Long postCreatorId;
+    private Long spaceId;
 
     private Long boardId;
+
+    private Long postCreatorId;
 
     private String title;
 
@@ -25,9 +27,10 @@ public class CreatePostCommand {
     private Boolean isAnonymous;
 
     @Builder
-    public CreatePostCommand(Long postCreatorId, Long boardId, String title, String content, List<AttachmentOfCreate> attachments, Boolean isAnonymous) {
-        this.postCreatorId = postCreatorId;
+    public CreatePostCommand(Long spaceId, Long boardId, Long postCreatorId, String title, String content, List<AttachmentOfCreate> attachments, Boolean isAnonymous) {
+        this.spaceId = spaceId;
         this.boardId = boardId;
+        this.postCreatorId = postCreatorId;
         this.title = title;
         this.content = Content.of(content);
         this.attachments = mapToInputModel(attachments);

--- a/src/main/java/space/space_spring/domain/post/application/port/in/createPost/CreatePostCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/createPost/CreatePostCommand.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import space.space_spring.domain.post.adapter.in.web.createPost.AttachmentOfCreate;
 import space.space_spring.domain.post.domain.Content;
 import space.space_spring.domain.post.domain.Post;
+import space.space_spring.global.common.entity.BaseInfo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,12 +41,12 @@ public class CreatePostCommand {
     private static List<AttachmentOfCreateCommand> mapToInputModel(List<AttachmentOfCreate> attachments) {
         List<AttachmentOfCreateCommand> result = new ArrayList<>();
         for (AttachmentOfCreate attachment : attachments) {
-            result.add(AttachmentOfCreateCommand.create(attachment.getValueOfAttachmentType(), attachment.getAttachmentUrl()));
+            result.add(AttachmentOfCreateCommand.create(attachment.getValueOfAttachmentType(), attachment.getAttachment()));
         }
         return result;
     }
 
     public Post toPostDomainEntity(Long discordMessageId) {
-        return Post.withoutId(discordMessageId, boardId, postCreatorId, title, content, isAnonymous);
+        return Post.withoutId(discordMessageId, boardId, postCreatorId, title, content, BaseInfo.ofEmpty(), isAnonymous);
     }
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/in/createPost/CreatePostUseCase.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/createPost/CreatePostUseCase.java
@@ -2,7 +2,7 @@ package space.space_spring.domain.post.application.port.in.createPost;
 
 public interface CreatePostUseCase {
 
-    Long createPostFromWeb(Long spaceMemberId, Long spaceId, CreatePostCommand command);
+    Long createPostFromWeb(CreatePostCommand command);
 
     Long createPostFromDiscord(CreatePostCommand command, Long discordId);
 }

--- a/src/main/java/space/space_spring/domain/post/application/service/CreatePostService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/CreatePostService.java
@@ -16,7 +16,7 @@ import space.space_spring.domain.spaceMember.application.port.out.LoadSpaceMembe
 import space.space_spring.domain.spaceMember.domian.SpaceMember;
 import space.space_spring.global.exception.CustomException;
 
-import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.UNAUTHORIZED_USER;
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.*;
 
 
 @Service
@@ -39,7 +39,7 @@ public class CreatePostService implements CreatePostUseCase {
         SpaceMember spaceMember = loadSpaceMemberPort.loadById(command.getPostCreatorId());
 
         // 3. validate
-//        validateBoardAndSpaceMember(board, spaceMember, command);
+        validateBoardAndSpaceMember(board, spaceMember, command);
 
         // 4. 디스코드로 게시글 정보 전송
         Long discordIdForPost = createPostInDiscordUseCase.createPostInDiscord(mapToDiscordCommand(command));
@@ -69,21 +69,21 @@ public class CreatePostService implements CreatePostUseCase {
                 .build();
     }
 
-//    private void validateBoardAndSpaceMember(Board board, SpaceMember spaceMember, CreatePostCommand command) {
-//        // 1. 해당 게시판이 스페이스에 속하는 지
-//        if (!board.isInSpace(command.getSpaceId())) {
-//            throw new CustomException(BOARD_IS_NOT_IN_SPACE);
-//        }
-//
-//        // 2. 질문 게시판이 아닌 게시판의 익명 여부가 FALSE인지
-//        if (board.getBoardType() != BoardType.QUESTION && command.getIsAnonymous()) {
-//            throw new CustomException(CAN_NOT_BE_ANONYMOUS);
-//        }
-//
-//        // 3. 공지사항, 기수별 공지사항의 작성자가 운영진인지
-//        if ((board.getBoardType() == BoardType.NOTICE || board.getBoardType() == BoardType.SEASON_NOTICE)
-//            && !spaceMember.isManager()) {
-//            throw new CustomException(UNAUTHORIZED_USER);
-//        }
-//    }
+    private void validateBoardAndSpaceMember(Board board, SpaceMember spaceMember, CreatePostCommand command) {
+        // 1. 해당 게시판이 스페이스에 속하는 지
+        if (!board.isInSpace(command.getSpaceId())) {
+            throw new CustomException(BOARD_IS_NOT_IN_SPACE);
+        }
+
+        // 2. 질문 게시판이 아닌 게시판의 익명 여부가 FALSE인지
+        if (board.getBoardType() != BoardType.QUESTION && command.getIsAnonymous()) {
+            throw new CustomException(CAN_NOT_BE_ANONYMOUS);
+        }
+
+        // 3. 공지사항, 기수별 공지사항의 작성자가 운영진인지
+        if ((board.getBoardType() == BoardType.NOTICE || board.getBoardType() == BoardType.SEASON_NOTICE)
+            && !spaceMember.isManager()) {
+            throw new CustomException(UNAUTHORIZED_USER);
+        }
+    }
 }

--- a/src/main/java/space/space_spring/domain/post/application/service/CreatePostService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/CreatePostService.java
@@ -3,18 +3,25 @@ package space.space_spring.domain.post.application.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import space.space_spring.domain.discord.application.port.in.createPost.CreatePostInDiscordCommand;
 import space.space_spring.domain.discord.application.port.in.createPost.CreatePostInDiscordUseCase;
+import space.space_spring.domain.post.application.port.in.createPost.AttachmentInDiscordCommand;
+import space.space_spring.domain.post.application.port.in.createPost.AttachmentOfCreateCommand;
 import space.space_spring.domain.post.application.port.in.createPost.CreatePostCommand;
 import space.space_spring.domain.post.application.port.in.createPost.CreatePostUseCase;
 import space.space_spring.domain.post.application.port.out.CreatePostPort;
 import space.space_spring.domain.post.application.port.out.LoadBoardPort;
-import space.space_spring.domain.post.domain.Board;
-import space.space_spring.domain.post.domain.BoardType;
-import space.space_spring.domain.post.domain.Post;
+import space.space_spring.domain.post.application.port.out.UploadAttachmentPort;
+import space.space_spring.domain.post.domain.*;
 import space.space_spring.domain.spaceMember.application.port.out.LoadSpaceMemberPort;
 import space.space_spring.domain.spaceMember.domian.SpaceMember;
 import space.space_spring.global.exception.CustomException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.*;
 
@@ -27,6 +34,7 @@ public class CreatePostService implements CreatePostUseCase {
     private final CreatePostPort createPostPort;
     private final LoadBoardPort loadBoardPort;
     private final LoadSpaceMemberPort loadSpaceMemberPort;
+    private final UploadAttachmentPort uploadAttachmentPort;
     private final CreatePostInDiscordUseCase createPostInDiscordUseCase;
 
     @Override
@@ -41,31 +49,58 @@ public class CreatePostService implements CreatePostUseCase {
         // 3. validate
         validateBoardAndSpaceMember(board, spaceMember, command);
 
+        // 4. S3에 게시글 첨부파일 upload
+        Map<AttachmentType, List<MultipartFile>> attachmentsMap = command.getAttachments().stream()
+                .collect(Collectors.groupingBy(
+                        AttachmentOfCreateCommand::getAttachmentType,
+                        Collectors.mapping(AttachmentOfCreateCommand::getAttachment, Collectors.toUnmodifiableList())
+                ));
+        Map<AttachmentType, List<String>> attachmentUrlsMap = uploadAttachmentPort.uploadAllAttachments(attachmentsMap, "post");
+
         // 4. 디스코드로 게시글 정보 전송
-        Long discordIdForPost = createPostInDiscordUseCase.createPostInDiscord(mapToDiscordCommand(command));
+        List<AttachmentInDiscordCommand> discordAttachments = new ArrayList<>();
+        attachmentUrlsMap.forEach((type, urls) -> urlsToAttachmentCommands(type, urls, discordAttachments));
 
-        // 5. Post 도메인 엔티티 생성 후 Adapter에 저장
+        Long discordIdForPost = createPostInDiscordUseCase.createPostInDiscord(mapToDiscordCommand(command, discordAttachments));
+
+        // 5. Post 도메인 엔티티 생성 후 db에 저장
         Post post = command.toPostDomainEntity(discordIdForPost);
+        Long postId = createPostPort.createPost(post);
 
-        return createPostPort.createPost(post);
+        // 6. Attachment 도메인 엔티티 생성 후 db에 저장
+        List<Attachment> attachments = new ArrayList<>();
+        attachmentUrlsMap.forEach((type, urls) -> urls.forEach(url ->
+                attachments.add(Attachment.withoutId(postId, type, url))
+        ));
+        return postId;
     }
 
     @Override
     @Transactional
     public Long createPostFromDiscord(CreatePostCommand command, Long discordId) {
-        // 1. Post 도메인 엔티티 생성 후 Adapter에 저장
+        // 1. Post 도메인 엔티티 생성 후 db에 저장
         Post post = command.toPostDomainEntity(discordId);
+        Long postId = createPostPort.createPost(post);
 
-        return createPostPort.createPost(post);
+        // 2. Attachment 도메인 엔티티 생성 후 db에 저장
+        /**
+         * TODO : 게시글 생성 Discord Input, attachment 파일 형식 정해진 후 리팩토링
+         */
+        List<Attachment> attachments = new ArrayList<>();
+
+        return postId;
     }
 
 
-    private CreatePostInDiscordCommand mapToDiscordCommand(CreatePostCommand command) {
+    private CreatePostInDiscordCommand mapToDiscordCommand(CreatePostCommand command, List<AttachmentInDiscordCommand> attachments) {
         return CreatePostInDiscordCommand.builder()
-                .postCreatorId(command.getPostCreatorId())
+                .spaceId(command.getSpaceId())
                 .boardId(command.getBoardId())
+                .postCreatorId(command.getPostCreatorId())
                 .title(command.getTitle())
-                .attachments(command.getAttachments())
+                .content(command.getContent())
+                .attachments(attachments)
+                .isAnonymous(command.getIsAnonymous())
                 .build();
     }
 
@@ -85,5 +120,9 @@ public class CreatePostService implements CreatePostUseCase {
             && !spaceMember.isManager()) {
             throw new CustomException(UNAUTHORIZED_USER);
         }
+    }
+
+    private void urlsToAttachmentCommands(AttachmentType attachmentType, List<String> attachmentUrls, List<AttachmentInDiscordCommand> commands) {
+        attachmentUrls.forEach(url -> commands.add(AttachmentInDiscordCommand.create(attachmentType.name(), url)));
     }
 }

--- a/src/main/java/space/space_spring/domain/post/application/service/CreatePostService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/CreatePostService.java
@@ -8,7 +8,15 @@ import space.space_spring.domain.discord.application.port.in.createPost.CreatePo
 import space.space_spring.domain.post.application.port.in.createPost.CreatePostCommand;
 import space.space_spring.domain.post.application.port.in.createPost.CreatePostUseCase;
 import space.space_spring.domain.post.application.port.out.CreatePostPort;
+import space.space_spring.domain.post.application.port.out.LoadBoardPort;
+import space.space_spring.domain.post.domain.Board;
+import space.space_spring.domain.post.domain.BoardType;
 import space.space_spring.domain.post.domain.Post;
+import space.space_spring.domain.spaceMember.application.port.out.LoadSpaceMemberPort;
+import space.space_spring.domain.spaceMember.domian.SpaceMember;
+import space.space_spring.global.exception.CustomException;
+
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.UNAUTHORIZED_USER;
 
 
 @Service
@@ -17,18 +25,26 @@ import space.space_spring.domain.post.domain.Post;
 public class CreatePostService implements CreatePostUseCase {
 
     private final CreatePostPort createPostPort;
+    private final LoadBoardPort loadBoardPort;
+    private final LoadSpaceMemberPort loadSpaceMemberPort;
     private final CreatePostInDiscordUseCase createPostInDiscordUseCase;
 
     @Override
     @Transactional
-    public Long createPostFromWeb(Long spaceMemberId, Long spaceId, CreatePostCommand command) {
+    public Long createPostFromWeb(CreatePostCommand command) {
+        // 1. Board 조회
+        Board board = loadBoardPort.loadById(command.getBoardId());
 
+        // 2. SpaceMember 조회
+        SpaceMember spaceMember = loadSpaceMemberPort.loadById(command.getPostCreatorId());
 
+        // 3. validate
+//        validateBoardAndSpaceMember(board, spaceMember, command);
 
-        // 1. 디스코드로 게시글 정보 전송
+        // 4. 디스코드로 게시글 정보 전송
         Long discordIdForPost = createPostInDiscordUseCase.createPostInDiscord(mapToDiscordCommand(command));
 
-        // 2. Post 도메인 엔티티 생성 후 Adapter에 저장
+        // 5. Post 도메인 엔티티 생성 후 Adapter에 저장
         Post post = command.toPostDomainEntity(discordIdForPost);
 
         return createPostPort.createPost(post);
@@ -44,7 +60,6 @@ public class CreatePostService implements CreatePostUseCase {
     }
 
 
-
     private CreatePostInDiscordCommand mapToDiscordCommand(CreatePostCommand command) {
         return CreatePostInDiscordCommand.builder()
                 .postCreatorId(command.getPostCreatorId())
@@ -54,4 +69,21 @@ public class CreatePostService implements CreatePostUseCase {
                 .build();
     }
 
+//    private void validateBoardAndSpaceMember(Board board, SpaceMember spaceMember, CreatePostCommand command) {
+//        // 1. 해당 게시판이 스페이스에 속하는 지
+//        if (!board.isInSpace(command.getSpaceId())) {
+//            throw new CustomException(BOARD_IS_NOT_IN_SPACE);
+//        }
+//
+//        // 2. 질문 게시판이 아닌 게시판의 익명 여부가 FALSE인지
+//        if (board.getBoardType() != BoardType.QUESTION && command.getIsAnonymous()) {
+//            throw new CustomException(CAN_NOT_BE_ANONYMOUS);
+//        }
+//
+//        // 3. 공지사항, 기수별 공지사항의 작성자가 운영진인지
+//        if ((board.getBoardType() == BoardType.NOTICE || board.getBoardType() == BoardType.SEASON_NOTICE)
+//            && !spaceMember.isManager()) {
+//            throw new CustomException(UNAUTHORIZED_USER);
+//        }
+//    }
 }

--- a/src/main/java/space/space_spring/domain/post/domain/Post.java
+++ b/src/main/java/space/space_spring/domain/post/domain/Post.java
@@ -37,7 +37,7 @@ public class Post {
         return new Post(id, discordId, boardId, spaceMemberId, title, content, baseInfo, isAnonymous);
     }
 
-    public static Post withoutId(Long discordId, Long boardId, Long spaceMemberId, String title, Content content, Boolean isAnonymous) {
-        return new Post(null, discordId, boardId, spaceMemberId, title, content, BaseInfo.ofEmpty(), isAnonymous);
+    public static Post withoutId(Long discordId, Long boardId, Long spaceMemberId, String title, Content content, BaseInfo baseInfo, Boolean isAnonymous) {
+        return new Post(null, discordId, boardId, spaceMemberId, title, content, baseInfo, isAnonymous);
     }
 }


### PR DESCRIPTION
## 📝 요약

이슈 번호 : #261

## 🔖 변경 사항
- 게시글 생성 web input 시, attachment 타입 MultipartFile
- 디스코드와 서버 간 attachment 타입 String

게시글 생성 web input 서비스 로직
1. 검증
  - 해당 게시판이 스페이스에 속하는 지
  - 질문 게시판이 아닌 게시판의 익명 여부가 FALSE인지
  - 공지사항, 기수별 공지사항의 작성자가 운영진인지
2. S3에 게시글 첨부파일 upload
3. 디스코드로 게시글 정보 전송
4. Post, Attachment 도메인 엔티티 생성 후 db에 저장

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
