### PR TITLE
fix : 게시글 상세 조회시 좋아요 개수 수정

### DIFF
--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/like/LikeJpaEntity.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/like/LikeJpaEntity.java
@@ -34,15 +34,15 @@ public class LikeJpaEntity extends BaseJpaEntity {
 
     @Column(name="is_liked")
     @NotNull
-    private boolean isLiked;    // 좋아요 여부
+    private Boolean isLiked;    // 좋아요 여부
 
-    private LikeJpaEntity(PostBaseJpaEntity postBase, SpaceMemberJpaEntity spaceMember, boolean isLiked) {
+    private LikeJpaEntity(PostBaseJpaEntity postBase, SpaceMemberJpaEntity spaceMember, Boolean isLiked) {
         this.postBase = postBase;
         this.spaceMember = spaceMember;
         this.isLiked = isLiked;
     }
 
-    public static LikeJpaEntity create(PostBaseJpaEntity postBase, SpaceMemberJpaEntity spaceMember, boolean isLiked) {
+    public static LikeJpaEntity create(PostBaseJpaEntity postBase, SpaceMemberJpaEntity spaceMember, Boolean isLiked) {
         return new LikeJpaEntity(postBase, spaceMember, isLiked);
     }
 

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/like/LikeMapper.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/like/LikeMapper.java
@@ -20,7 +20,7 @@ public class LikeMapper {
                 jpaEntity.getId(),
                 jpaEntity.getPostBase().getId(),
                 jpaEntity.getSpaceMember().getId(),
-                jpaEntity.isLiked(),
+                jpaEntity.getIsLiked(),
                 baseInfo
         );
     }
@@ -29,7 +29,7 @@ public class LikeMapper {
         return LikeJpaEntity.create(
                 postBaseJpaEntity,
                 spaceMemberJpaEntity,
-                domain.isLiked()
+                domain.getIsLiked()
         );
     }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/like/LikePersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/like/LikePersistenceAdapter.java
@@ -32,6 +32,7 @@ public class LikePersistenceAdapter implements LoadLikePort, CreateLikePort, Cha
 
     @Override
     public Map<Long, NaturalNumber> countLikesByPostIds(List<Long> postIds) {
+        // Like 테이블에서 못찾은 경우(= 해당 postId에 좋아요가 달리지 않은 경우) -> 해당 게시물(or 댓글)에 해당하는 PostLikeCount 객체는 존재하지 않는다
         List<PostLikeCount> results = likeRepository.countLikesByPostIds(postIds, BaseStatusType.ACTIVE);
         return results.stream()
                 .collect(Collectors.toMap(
@@ -42,7 +43,11 @@ public class LikePersistenceAdapter implements LoadLikePort, CreateLikePort, Cha
 
     @Override
     public NaturalNumber countLikeByPostId(Long postId) {
+        // Like 테이블에서 못찾은 경우(= 해당 postId에 좋아요가 달리지 않은 경우) -> likeCountOfTarget의 값은 0이다 (= defaultValue)
         int likeCountOfTarget = likeRepository.countByPostBaseIdAndIsLikedAndStatus(postId, true, BaseStatusType.ACTIVE);
+
+//        System.out.println("likeCountOfTarget = " + likeCountOfTarget);
+
         return NaturalNumber.of(likeCountOfTarget);
     }
 

--- a/src/main/java/space/space_spring/domain/post/application/service/ReadPostDetailService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/ReadPostDetailService.java
@@ -121,7 +121,7 @@ public class ReadPostDetailService implements ReadPostDetailUseCase {
                 .content(comment.getContent())
                 .createdAt(ConvertCreatedDate.setCreatedDate(comment.getBaseInfo().getCreatedAt()))
                 .lastModifiedAt(ConvertCreatedDate.setCreatedDate(comment.getBaseInfo().getLastModifiedAt()))
-                .likeCount(commentLikeCountMap.get(comment.getId()))
+                .likeCount(commentLikeCountMap.getOrDefault(comment.getId(), NaturalNumber.of(0)))
                 .isLiked(hasSpaceMemberLikedToComment)
                 .isActiveComment(isActiveComment)
                 .build();

--- a/src/main/java/space/space_spring/domain/post/domain/Like.java
+++ b/src/main/java/space/space_spring/domain/post/domain/Like.java
@@ -12,11 +12,11 @@ public class Like {
 
     private Long spaceMemberId;
 
-    private boolean isLiked;
+    private Boolean isLiked;
 
     private BaseInfo baseInfo;
 
-    private Like(Long id, Long targetId, Long spaceMemberId, boolean isLiked, BaseInfo baseInfo) {
+    private Like(Long id, Long targetId, Long spaceMemberId, Boolean isLiked, BaseInfo baseInfo) {
         this.id = id;
         this.targetId = targetId;
         this.spaceMemberId = spaceMemberId;
@@ -24,11 +24,11 @@ public class Like {
         this.baseInfo = baseInfo;
     }
 
-    public static Like of(Long id, Long targetId, Long spaceMemberId, boolean isLiked, BaseInfo baseInfo) {
+    public static Like of(Long id, Long targetId, Long spaceMemberId, Boolean isLiked, BaseInfo baseInfo) {
         return new Like(id, targetId, spaceMemberId, isLiked, baseInfo);
     }
 
-    public static Like withoutId(Long targetId, Long spaceMemberId, boolean isLiked) {
+    public static Like withoutId(Long targetId, Long spaceMemberId, Boolean isLiked) {
         return new Like(null, targetId, spaceMemberId, isLiked, BaseInfo.ofEmpty());
     }
 }


### PR DESCRIPTION
## 📝 요약
기존 좋아요 개수 세는 로직은 Like 테이블에서 좋아요 대상의 postBaseId를 가지고 jpql의 count 메서드를 활용합니다
그런데 좋아요 개수를 세고자하는 postBase가 아직 좋아요를 못받은 경우, Like 테이블에 해당 데이터가 없기 때문에, adapter에서 반환받은 Map에 get메서드를 적용해서 NullPointerException 이 발생한 것이었습니다
-> getOrDefault 메서드로 수정 (@arkchive 님 코드 참고했습니다!)

이슈 번호 : #329 

## 🔖 변경 사항

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)
로컬 서버에서 확인해봤습니다!

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
