### PR TITLE
Fix/#334/게시판 목록 조회 오류

### DIFF
--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/createPost/RequestOfCreatePost.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/createPost/RequestOfCreatePost.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 import space.space_spring.global.common.validation.SelfValidating;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -27,7 +28,7 @@ public class RequestOfCreatePost extends SelfValidating<RequestOfCreatePost> {
     private String content;
 
     @Nullable
-    private List<MultipartFile> attachments;
+    private List<MultipartFile> attachments = new ArrayList<>();
 
     @NotNull(message = "게시글의 익명/비익명 여부는 공백일 수 없습니다.")
     private Boolean isAnonymous; // 질문일 경우만 사용

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/updatePost/RequestOfUpdatePost.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/updatePost/RequestOfUpdatePost.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 import space.space_spring.global.common.validation.SelfValidating;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -24,7 +25,7 @@ public class RequestOfUpdatePost extends SelfValidating<RequestOfUpdatePost> {
     private String content;
 
     @Nullable
-    private List<MultipartFile> attachments;
+    private List<MultipartFile> attachments = new ArrayList<>();
 
     @NotNull(message = "게시글의 익명/비익명 여부는 공백일 수 없습니다.")
     private Boolean isAnonymous; // 질문일 경우만 사용

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/subscription/SubscriptionPersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/subscription/SubscriptionPersistenceAdapter.java
@@ -5,8 +5,11 @@ import static space.space_spring.global.common.response.status.BaseExceptionResp
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.SPACE_MEMBER_NOT_FOUND;
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.TAG_NOT_FOUND;
 
+import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -43,13 +46,19 @@ public class SubscriptionPersistenceAdapter implements LoadSubscriptionPort, Cre
     }
 
     @Override
-    public List<Long> loadSubscribedBoardIds(Long spaceMemberId) {
-        return subscriptionRepository.findSubscribedBoardIdsBySpaceMemberId(spaceMemberId);
+    public Optional<Subscription> loadByBoardId(Long boardId) {
+        return subscriptionRepository.findByBoardIdAndStatus(boardId, ACTIVE).map(subscriptionMapper::toDomainEntity);
     }
 
     @Override
-    public Optional<Subscription> loadByBoardId(Long boardId) {
-        return subscriptionRepository.findByBoardIdAndStatus(boardId, ACTIVE).map(subscriptionMapper::toDomainEntity);
+    public List<Map.Entry<Long, Long>> loadSubscribedBoardTagPairs(Long spaceMemberId) {
+        List<Object[]> results = subscriptionRepository.findSubscribedBoardTagPairs(spaceMemberId);
+
+        return results.stream()
+                .map(result -> new AbstractMap.SimpleEntry<>(
+                        (Long) result[0],
+                        result[1] != null ? (Long) result[1] : null
+                )).collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/subscription/SubscriptionRepository.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/subscription/SubscriptionRepository.java
@@ -14,8 +14,7 @@ public interface SubscriptionRepository extends JpaRepository<SubscriptionJpaEnt
 
     Optional<SubscriptionJpaEntity> findByBoardIdAndStatus(Long boardId, BaseStatusType baseStatusType);
 
-
-    // 특정 사용자가 구독한 게시판 ID 조회
-    @Query("SELECT s.board.id FROM SubscriptionJpaEntity s WHERE s.spaceMember.id = :spaceMemberId")
-    List<Long> findSubscribedBoardIdsBySpaceMemberId(@Param("spaceMemberId") Long spaceMemberId);
+    // 특정 사용자가 구독한 게시판+태그 조회
+    @Query("SELECT s.board.id, s.tag.id FROM SubscriptionJpaEntity s WHERE s.spaceMember.id = :spaceMemberId")
+    List<Object[]> findSubscribedBoardTagPairs(@Param("spaceMemberId") Long spaceMemberId);
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/out/LoadSubscriptionPort.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/out/LoadSubscriptionPort.java
@@ -1,6 +1,7 @@
 package space.space_spring.domain.post.application.port.out;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import space.space_spring.domain.post.domain.Subscription;
 
@@ -9,6 +10,7 @@ public interface LoadSubscriptionPort {
     Optional<Subscription> loadByInfos(Long spaceMemberId, Long boardId, Long tagId);
 
     Optional<Subscription> loadByBoardId(Long boardId);
-    // 사용자가 구독한 게시판 ID 목록 조회
-    List<Long> loadSubscribedBoardIds(Long spaceMemberId);
+
+    // 사용자가 구독한 게시판+태그 목록 조회
+    List<Map.Entry<Long, Long>> loadSubscribedBoardTagPairs(Long spaceMemberId);
 }

--- a/src/main/java/space/space_spring/domain/post/application/service/ReadBoardListService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/ReadBoardListService.java
@@ -15,6 +15,7 @@ import space.space_spring.domain.post.domain.Tag;
 import java.util.*;
 import java.util.stream.Collectors;
 
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -37,21 +38,25 @@ public class ReadBoardListService implements ReadBoardListUseCase {
         List<Tag> tagList = loadTagPort.loadTagsByBoardIds(boardIds);
 
         // 3. 태그를 boardId 기준으로 매핑
-        Map<Long, Tag> tagMap = tagList.stream()
-                .collect(Collectors.toMap(Tag::getBoardId, tag -> tag));
+        Map<Long, List<Tag>> tagMap = tagList.stream()
+                .collect(Collectors.groupingBy(Tag::getBoardId));
 
         // 4. 사용자가 구독한 게시판 id 조회
         Set<Long> subscribedBoardIds = new HashSet<>(loadSubscriptionPort.loadSubscribedBoardIds(spaceMemberId));
 
         // 5. 게시판 목록 리스트 생성
         List<ReadBoardInfoCommand> boardInfoCommands = boardList.stream()
-                .map(board -> ReadBoardInfoCommand.of(
-                        board.getId(),
-                        board.getBoardName(),
-                        tagMap.get(board.getId()) != null ? tagMap.get(board.getId()).getId() : null,
-                        tagMap.get(board.getId()) != null ? tagMap.get(board.getId()).getTagName() : null,
-                        subscribedBoardIds.contains(board.getId())
-                )).toList();
+                .flatMap(board -> {
+                    List<Tag> tags = tagMap.getOrDefault(board.getId(), Collections.emptyList());
+                    return tags.stream()
+                            .map(tag -> ReadBoardInfoCommand.of(
+                                    board.getId(),
+                                    board.getBoardName(),
+                                    tag.getId(),
+                                    tag.getTagName(),
+                                    subscribedBoardIds.contains(board.getId())
+                            ));
+                }).toList();
 
         return ReadBoardListCommand.of(boardInfoCommands);
     }

--- a/src/main/java/space/space_spring/domain/post/application/service/ReadBoardListService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/ReadBoardListService.java
@@ -14,6 +14,7 @@ import space.space_spring.domain.post.domain.Tag;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 @Service
@@ -48,6 +49,16 @@ public class ReadBoardListService implements ReadBoardListUseCase {
         List<ReadBoardInfoCommand> boardInfoCommands = boardList.stream()
                 .flatMap(board -> {
                     List<Tag> tags = tagMap.getOrDefault(board.getId(), Collections.emptyList());
+                    if (tags.isEmpty()) {
+                        // 태그가 없는 경우 응답 생성
+                        return Stream.of(ReadBoardInfoCommand.of(
+                                board.getId(),
+                                board.getBoardName(),
+                                null,
+                                null,
+                                subscribedBoardIds.contains(board.getId())
+                        ));
+                    }
                     return tags.stream()
                             .map(tag -> ReadBoardInfoCommand.of(
                                     board.getId(),


### PR DESCRIPTION
## 📝 요약
게시판 목록 조회 시, duplicate key 에러 발생

이슈 번호 : #334

## 🔖 변경 사항
- boardId를 기준으로 태그 매핑 시, 단일 태그 값이 아닌 List<Tag>로 변경
- 태그가 없는 보드 조회 처리

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
