### PR TITLE
Feat : 디스코드 생성 게시물에 생성 시간 주입

### DIFF
--- a/src/main/java/space/space_spring/domain/discord/adapter/in/discord/ButtonInteraction/CreateChannel/MoveCurrentChannelMessageButtonProcessor.java
+++ b/src/main/java/space/space_spring/domain/discord/adapter/in/discord/ButtonInteraction/CreateChannel/MoveCurrentChannelMessageButtonProcessor.java
@@ -12,15 +12,19 @@ import space.space_spring.domain.discord.application.port.out.CreateDiscordWebHo
 import space.space_spring.domain.post.application.port.in.boardCache.LoadBoardCacheUseCase;
 import space.space_spring.domain.post.application.port.in.loadBoard.LoadBoardUseCase;
 import space.space_spring.domain.post.application.port.out.LoadPostPort;
+import space.space_spring.domain.post.domain.AttachmentType;
 import space.space_spring.domain.space.application.port.in.LoadSpaceUseCase;
 import space.space_spring.global.exception.CustomException;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static space.space_spring.domain.discord.adapter.in.discord.DiscordMessageMapper.getAttachmentType;
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.BOARD_NOT_FOUND;
 
 @Component
@@ -64,6 +68,7 @@ public class MoveCurrentChannelMessageButtonProcessor implements ButtonInteracti
         // 각 메시지에 대해 비동기 작업 수행
         List<CompletableFuture<Void>> futures = messages.stream()
                 .filter(message->loadPostPort.loadByDiscordId(message.getIdLong()).isEmpty())
+                .filter(message->message.getMember()!=null)
                 .map(message -> {
                     return CompletableFuture.runAsync(()->{
                             inputMessageFromDiscordUseCase.putPost(mapToServer(message, boardId));
@@ -118,6 +123,9 @@ public class MoveCurrentChannelMessageButtonProcessor implements ButtonInteracti
 
     private MessageInputFromDiscordCommand mapToServer(Message message, Long boardId){
         TitleContent titleContent = parseTitleAndContent(message.getContentRaw());
+        Map<String, AttachmentType> attachments = new HashMap<>();
+
+       message.getAttachments().forEach(attachment -> attachments.put(attachment.getUrl(),getAttachmentType(attachment.getContentType())));
 
         return MessageInputFromDiscordCommand.builder()
                 .boardId(boardId)
@@ -129,6 +137,7 @@ public class MoveCurrentChannelMessageButtonProcessor implements ButtonInteracti
                 .content(titleContent.content())
                 .createdAt(message.getTimeCreated())
                 .lastModifiedAt(message.getTimeEdited())
+                .attachments(attachments)
                 .build();
     }
 }

--- a/src/main/java/space/space_spring/domain/discord/adapter/in/discord/ButtonInteraction/CreateChannel/MoveCurrentChannelMessageButtonProcessor.java
+++ b/src/main/java/space/space_spring/domain/discord/adapter/in/discord/ButtonInteraction/CreateChannel/MoveCurrentChannelMessageButtonProcessor.java
@@ -119,9 +119,6 @@ public class MoveCurrentChannelMessageButtonProcessor implements ButtonInteracti
     private MessageInputFromDiscordCommand mapToServer(Message message, Long boardId){
         TitleContent titleContent = parseTitleAndContent(message.getContentRaw());
 
-        //Todo 생성 시간 주입
-        message.getTimeCreated();
-
         return MessageInputFromDiscordCommand.builder()
                 .boardId(boardId)
                 .MessageDiscordId(message.getIdLong())
@@ -130,6 +127,8 @@ public class MoveCurrentChannelMessageButtonProcessor implements ButtonInteracti
                 .spaceDiscordId(message.getGuildIdLong())
                 .title(titleContent.title())
                 .content(titleContent.content())
+                .createdTime(message.getTimeCreated())
+                .lastModifiedAt(message.getTimeEdited())
                 .build();
     }
 }

--- a/src/main/java/space/space_spring/domain/discord/adapter/in/discord/ButtonInteraction/CreateChannel/MoveCurrentChannelMessageButtonProcessor.java
+++ b/src/main/java/space/space_spring/domain/discord/adapter/in/discord/ButtonInteraction/CreateChannel/MoveCurrentChannelMessageButtonProcessor.java
@@ -127,7 +127,7 @@ public class MoveCurrentChannelMessageButtonProcessor implements ButtonInteracti
                 .spaceDiscordId(message.getGuildIdLong())
                 .title(titleContent.title())
                 .content(titleContent.content())
-                .createdTime(message.getTimeCreated())
+                .createdAt(message.getTimeCreated())
                 .lastModifiedAt(message.getTimeEdited())
                 .build();
     }

--- a/src/main/java/space/space_spring/domain/discord/adapter/in/discord/DiscordMessageMapper.java
+++ b/src/main/java/space/space_spring/domain/discord/adapter/in/discord/DiscordMessageMapper.java
@@ -72,6 +72,8 @@ public class DiscordMessageMapper {
                 .tagDiscordIds(tagDiscordIds)
                 .content(content)
                 .attachments(attachments)
+                .createdTime(event.getMessage().getTimeCreated())
+                .lastModifiedAt(event.getMessage().getTimeEdited())
                 .build();
 
     }

--- a/src/main/java/space/space_spring/domain/discord/adapter/in/discord/DiscordMessageMapper.java
+++ b/src/main/java/space/space_spring/domain/discord/adapter/in/discord/DiscordMessageMapper.java
@@ -72,7 +72,7 @@ public class DiscordMessageMapper {
                 .tagDiscordIds(tagDiscordIds)
                 .content(content)
                 .attachments(attachments)
-                .createdTime(event.getMessage().getTimeCreated())
+                .createdAt(event.getMessage().getTimeCreated())
                 .lastModifiedAt(event.getMessage().getTimeEdited())
                 .build();
 

--- a/src/main/java/space/space_spring/domain/discord/application/port/in/discord/MessageInputFromDiscordCommand.java
+++ b/src/main/java/space/space_spring/domain/discord/application/port/in/discord/MessageInputFromDiscordCommand.java
@@ -24,7 +24,7 @@ public class MessageInputFromDiscordCommand {
     private Long MessageDiscordId;
     private Map<String, AttachmentType> attachments;
 
-    private OffsetDateTime createdTime;
+    private OffsetDateTime createdAt;
     private OffsetDateTime lastModifiedAt;
 
     @Override

--- a/src/main/java/space/space_spring/domain/discord/application/port/in/discord/MessageInputFromDiscordCommand.java
+++ b/src/main/java/space/space_spring/domain/discord/application/port/in/discord/MessageInputFromDiscordCommand.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import space.space_spring.domain.post.domain.AttachmentType;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -22,6 +23,9 @@ public class MessageInputFromDiscordCommand {
     private Long spaceDiscordId;
     private Long MessageDiscordId;
     private Map<String, AttachmentType> attachments;
+
+    private OffsetDateTime createdTime;
+    private OffsetDateTime lastModifiedAt;
 
     @Override
     public String toString(){

--- a/src/main/java/space/space_spring/domain/discord/application/port/in/discord/MessageInputFromDiscordCommand.java
+++ b/src/main/java/space/space_spring/domain/discord/application/port/in/discord/MessageInputFromDiscordCommand.java
@@ -53,4 +53,10 @@ public class MessageInputFromDiscordCommand {
         return false;
     }
 
+    public List<Long> getTagDiscordIds(){
+        if(this.tagDiscordIds==null){
+            return List.of();
+        }
+        return this.tagDiscordIds;
+    }
 }

--- a/src/main/java/space/space_spring/domain/discord/application/service/MessageInputFromDiscordService.java
+++ b/src/main/java/space/space_spring/domain/discord/application/service/MessageInputFromDiscordService.java
@@ -66,6 +66,8 @@ public class MessageInputFromDiscordService implements InputMessageFromDiscordUs
                         .postCreatorId(spaceMemberId)
                         .isAnonymous(false)
                         .tagIds(tagIds)
+                        .createdAt(command.getCreatedTime())
+                        .lastModifiedAt(command.getLastModifiedAt())
                         .build()
                 , command.getMessageDiscordId()
         );

--- a/src/main/java/space/space_spring/domain/discord/application/service/MessageInputFromDiscordService.java
+++ b/src/main/java/space/space_spring/domain/discord/application/service/MessageInputFromDiscordService.java
@@ -10,6 +10,7 @@ import space.space_spring.domain.discord.application.port.in.discord.InputMessag
 import space.space_spring.domain.discord.application.port.in.discord.MessageInputFromDiscordCommand;
 import space.space_spring.domain.post.application.port.in.Tag.LoadTagUseCase;
 import space.space_spring.domain.post.application.port.in.createComment.CreateCommentCommand;
+import space.space_spring.domain.post.application.port.in.createComment.CreateCommentUseCase;
 import space.space_spring.domain.post.application.port.in.createPost.CreatePostCommand;
 import space.space_spring.domain.post.application.port.in.createPost.CreatePostFromDiscordCommand;
 import space.space_spring.domain.post.application.port.in.createPost.CreatePostUseCase;
@@ -32,7 +33,7 @@ public class MessageInputFromDiscordService implements InputMessageFromDiscordUs
 
     private final LoadSpaceMemberPort loadSpaceMemberPort;
     private final LoadSpaceUseCase loadSpaceUseCase;
-    private final CreateCommentService createCommentService;
+    private final CreateCommentUseCase createCommentUseCase;
     private final CreatePostUseCase createPostUseCase;
     private final LoadTagUseCase loadTagUseCase;
 
@@ -66,7 +67,7 @@ public class MessageInputFromDiscordService implements InputMessageFromDiscordUs
                         .postCreatorId(spaceMemberId)
                         .isAnonymous(false)
                         .tagIds(tagIds)
-                        .createdAt(command.getCreatedTime())
+                        .createdAt(command.getCreatedAt())
                         .lastModifiedAt(command.getLastModifiedAt())
                         .build()
                 , command.getMessageDiscordId()
@@ -84,7 +85,7 @@ public class MessageInputFromDiscordService implements InputMessageFromDiscordUs
     @Override
     public void putComment(MessageInputFromDiscordCommand command,Long boardId){
 
-        createCommentService.createCommentFromDiscord(mapToCreateComment(command,boardId),command.getCreatorDiscordId());
+        createCommentUseCase.createCommentFromDiscord(mapToCreateComment(command,boardId),command.getCreatorDiscordId());
 
     }
 
@@ -99,6 +100,8 @@ public class MessageInputFromDiscordService implements InputMessageFromDiscordUs
                 .spaceId(spaceId)
                 .boardId(command.getBoardId())
                 .content(command.getContent())
+                .createdAt(command.getCreatedAt())
+                .lastModifiedAt(command.getLastModifiedAt())
                 .postId(boardId)
                 .build();
     }

--- a/src/main/java/space/space_spring/domain/post/application/port/in/createComment/CreateCommentCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/createComment/CreateCommentCommand.java
@@ -6,6 +6,8 @@ import space.space_spring.domain.post.adapter.in.web.createComment.RequestOfCrea
 import space.space_spring.domain.post.domain.Comment;
 import space.space_spring.domain.post.domain.Content;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Getter
@@ -23,14 +25,28 @@ public class CreateCommentCommand {
 
     private Boolean isAnonymous;        // 익명 댓글 여부
 
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime lastModifiedAt;
+
     @Builder
-    public CreateCommentCommand(Long spaceId, Long boardId, Long postId, Long commentCreatorId, String content, Boolean isAnonymous) {
+    public CreateCommentCommand(Long spaceId,
+                                Long boardId,
+                                Long postId,
+                                Long commentCreatorId,
+                                String content,
+                                Boolean isAnonymous,
+                                OffsetDateTime createdAt,
+                                OffsetDateTime lastModifiedAt) {
         this.spaceId = spaceId;
         this.boardId = boardId;
         this.postId = postId;
         this.commentCreatorId = commentCreatorId;
         this.content = content;
         this.isAnonymous = isAnonymous;
+        this.createdAt=createdAt.toLocalDateTime();
+        this.lastModifiedAt=lastModifiedAt==null?createdAt.toLocalDateTime() : lastModifiedAt.toLocalDateTime();
     }
 
 

--- a/src/main/java/space/space_spring/domain/post/application/port/in/createPost/CreatePostFromDiscordCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/createPost/CreatePostFromDiscordCommand.java
@@ -8,6 +8,8 @@ import space.space_spring.domain.post.domain.Content;
 import space.space_spring.domain.post.domain.Post;
 import space.space_spring.global.common.entity.BaseInfo;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -28,9 +30,22 @@ public class CreatePostFromDiscordCommand {
 
     private Map<String, AttachmentType> attachments;
     private Boolean isAnonymous;
+    private LocalDateTime createdAt;
+
+    private LocalDateTime lastModifiedAt;
 
     @Builder
-    public CreatePostFromDiscordCommand(Long spaceId, Long boardId, List<Long> tagIds, Long postCreatorId, String title, String content, Map<String, AttachmentType> attachments, Boolean isAnonymous) {
+    public CreatePostFromDiscordCommand(Long spaceId,
+                                        Long boardId,
+                                        List<Long> tagIds,
+                                        Long postCreatorId,
+                                        String title,
+                                        String content,
+                                        Map<String, AttachmentType> attachments,
+                                        Boolean isAnonymous,
+                                        OffsetDateTime createdAt,
+                                        OffsetDateTime lastModifiedAt
+    ) {
         this.spaceId = spaceId;
         this.boardId = boardId;
         this.tagIds = tagIds;
@@ -39,6 +54,8 @@ public class CreatePostFromDiscordCommand {
         this.content = Content.of(content);
         this.attachments = attachments;
         this.isAnonymous = isAnonymous;
+        this.createdAt = createdAt.toLocalDateTime();
+        this.lastModifiedAt = lastModifiedAt.toLocalDateTime();
     }
 
     public Post toPostDomainEntity(Long discordMessageId) {

--- a/src/main/java/space/space_spring/domain/post/application/port/in/createPost/CreatePostFromDiscordCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/createPost/CreatePostFromDiscordCommand.java
@@ -7,6 +7,7 @@ import space.space_spring.domain.post.domain.AttachmentType;
 import space.space_spring.domain.post.domain.Content;
 import space.space_spring.domain.post.domain.Post;
 import space.space_spring.global.common.entity.BaseInfo;
+import space.space_spring.global.common.enumStatus.BaseStatusType;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -55,10 +56,11 @@ public class CreatePostFromDiscordCommand {
         this.attachments = attachments;
         this.isAnonymous = isAnonymous;
         this.createdAt = createdAt.toLocalDateTime();
-        this.lastModifiedAt = lastModifiedAt.toLocalDateTime();
+        this.lastModifiedAt = lastModifiedAt==null? createdAt.toLocalDateTime() : lastModifiedAt.toLocalDateTime();
     }
 
     public Post toPostDomainEntity(Long discordMessageId) {
-        return Post.withoutId(discordMessageId, boardId, postCreatorId, title, content, BaseInfo.ofEmpty(), isAnonymous);
+        return Post.withoutId(discordMessageId, boardId, postCreatorId, title, content,
+                BaseInfo.of(createdAt,lastModifiedAt, BaseStatusType.ACTIVE), isAnonymous);
     }
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/in/updatePost/UpdatePostFromDiscordCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/updatePost/UpdatePostFromDiscordCommand.java
@@ -41,6 +41,9 @@ public class UpdatePostFromDiscordCommand {
 
     public Map<AttachmentType,List<String>> getNewAttachmentUrlMap(){
         // 변환 실행
+        if(newAttachmentUrlMap==null){
+            return Map.of();
+        }
         return newAttachmentUrlMap.entrySet()
                 .stream()
                 .collect(Collectors.groupingBy(


### PR DESCRIPTION
## 📝 요약
디스코드에서 생성된 메세지/댓글에 대해 디스코드 생성 시간을 주입해줍니다.
- 이슈 번호 : #266

## 🔖 변경 사항
- 게시물/댓글 생성 시 생성시간 주입
- 이전 게시물 옮기기 기능에도 적용
- null point exception 해결
- 메세지 수정의 경우 따로 처리하지 않음

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
