### PR TITLE
Fix/#364/스페이스에서의 익명 댓글 생성

### DIFF
--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/CommentQueryAdapter.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/comment/CommentQueryAdapter.java
@@ -92,8 +92,8 @@ public class CommentQueryAdapter implements CommentDetailQueryPort, CommentCreat
 
         return queryFactory.select(
                         Projections.constructor(AnonymousCommentCreatorView.class,
-                                // 댓글 작성자 프로필 이미지 URL
-                                commentBase.spaceMember.profileImageUrl,
+                                // 댓글 작성자 id
+                                commentBase.spaceMember.id,
                                 // 게시글 작성자와 댓글 작성자 비교
                                 Expressions.booleanTemplate(
                                         "({0} = {1})",

--- a/src/main/java/space/space_spring/domain/post/application/port/in/createComment/CreateCommentCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/createComment/CreateCommentCommand.java
@@ -45,7 +45,7 @@ public class CreateCommentCommand {
         this.commentCreatorId = commentCreatorId;
         this.content = content;
         this.isAnonymous = isAnonymous;
-        this.createdAt=createdAt.toLocalDateTime();
+        this.createdAt= createdAt.toLocalDateTime();
         this.lastModifiedAt=lastModifiedAt==null?createdAt.toLocalDateTime() : lastModifiedAt.toLocalDateTime();
     }
 

--- a/src/main/java/space/space_spring/domain/post/application/port/in/createComment/CreateCommentCommand.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/createComment/CreateCommentCommand.java
@@ -45,8 +45,8 @@ public class CreateCommentCommand {
         this.commentCreatorId = commentCreatorId;
         this.content = content;
         this.isAnonymous = isAnonymous;
-        this.createdAt= createdAt.toLocalDateTime();
-        this.lastModifiedAt=lastModifiedAt==null?createdAt.toLocalDateTime() : lastModifiedAt.toLocalDateTime();
+        this.createdAt = createdAt == null ? null : createdAt.toLocalDateTime();
+        this.lastModifiedAt = lastModifiedAt == null ? null : lastModifiedAt.toLocalDateTime();
     }
 
 

--- a/src/main/java/space/space_spring/domain/post/application/port/out/comment/AnonymousCommentCreatorView.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/out/comment/AnonymousCommentCreatorView.java
@@ -1,0 +1,22 @@
+package space.space_spring.domain.post.application.port.out.comment;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AnonymousCommentCreatorView {
+
+    private Long creatorId;
+
+    private Boolean isPostOwner;
+
+    private Boolean isActiveComment;
+
+    // QueryDsl에서 사용되는 생성자
+    public AnonymousCommentCreatorView(Long creatorId, Boolean isPostOwner, Boolean isActiveComment) {
+        this.creatorId = creatorId;
+        this.isPostOwner = isPostOwner;
+        this.isActiveComment = isActiveComment;
+    }
+}

--- a/src/main/java/space/space_spring/domain/post/application/port/out/comment/CommentCreatorQueryPort.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/out/comment/CommentCreatorQueryPort.java
@@ -1,0 +1,8 @@
+package space.space_spring.domain.post.application.port.out.comment;
+
+import java.util.List;
+
+public interface CommentCreatorQueryPort {
+
+    List<AnonymousCommentCreatorView> loadAnonymousCommentCreators(Long postId);
+}

--- a/src/main/java/space/space_spring/domain/post/application/service/CreateCommentService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/CreateCommentService.java
@@ -80,18 +80,19 @@ public class CreateCommentService implements CreateCommentUseCase {
             for (AnonymousCommentCreatorView view : anonymousCommentCreatorViews) {
                 Long creatorId = view.getCreatorId();
                 if (!anonymousNicknameMap.containsKey(creatorId)) {
-                    if (view.getIsPostOwner()) {
-                        anonymousNicknameMap.put(creatorId, "게시글 작성자");
-                    } else {
+                    if (!view.getIsPostOwner()) {
                         anonymousNicknameMap.put(creatorId, "익명 스페이서" + " " + anonymousCount++);
                     }
                 }
             }
 
-            if (anonymousNicknameMap.containsKey(command.getCommentCreatorId())) {
-                creatorNickname = anonymousNicknameMap.get(command.getCommentCreatorId());
-            } else {
-                creatorNickname = "익명 스페이서" + " " + anonymousCount;
+            if (post.isPostCreator(command.getCommentCreatorId())) creatorNickname = "게시글 작성자";
+            else {
+                if (anonymousNicknameMap.containsKey(command.getCommentCreatorId())) {
+                    creatorNickname = anonymousNicknameMap.get(command.getCommentCreatorId());
+                } else {
+                    creatorNickname = "익명 스페이서" + " " + anonymousCount;
+                }
             }
 
             creatorProfileImageUrl = null;

--- a/src/main/java/space/space_spring/domain/post/application/service/CreateCommentService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/CreateCommentService.java
@@ -74,6 +74,8 @@ public class CreateCommentService implements CreateCommentUseCase {
     }
 
     private String resolveAnonymousNickname(Long commentCreatorId, Post post) {
+        if (post.isPostCreator(commentCreatorId)) return POST_CREATOR_NICKNAME;
+
         List<AnonymousCommentCreatorView> anonymousViews = commentCreatorQueryPort.loadAnonymousCommentCreators(post.getId());
         Map<Long, String> anonymousNicknameMap = new HashMap<>();
         int anonymousIndex = 1;
@@ -85,11 +87,7 @@ public class CreateCommentService implements CreateCommentUseCase {
             }
         }
 
-        if (post.isPostCreator(commentCreatorId)) {
-            return POST_CREATOR_NICKNAME;
-        } else {
-            return anonymousNicknameMap.getOrDefault(commentCreatorId, ANONYMOUS_COMMENT_CREATOR + " " + anonymousIndex);
-        }
+        return anonymousNicknameMap.getOrDefault(commentCreatorId, ANONYMOUS_COMMENT_CREATOR + " " + anonymousIndex);
     }
 
     private void validateBoardAndPost(Board board, Post post, CreateCommentCommand command) {

--- a/src/main/java/space/space_spring/domain/post/application/service/strategy/AnonymousCommentProcessingStrategy.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/strategy/AnonymousCommentProcessingStrategy.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class AnonymousCommentProcessingStrategy implements CommentDetailProcessingStrategy {
 
-    private static final String ANONYMOUS_POST_AND_COMMENT_CREATOR_NICKNAME = "게시글 작성자";
+    private static final String POST_CREATOR_NICKNAME = "게시글 작성자";
     private static final String ANONYMOUS_COMMENT_CREATOR_NICKNAME = "익명 스페이서";
     private final Map<Long, String> anonymousNicknameMap = new HashMap<>();
     private int anonymousCount = 1;
@@ -22,7 +22,7 @@ public class AnonymousCommentProcessingStrategy implements CommentDetailProcessi
         if (comment.getIsPostOwner()) {
             return CommentDetailView.builder()
                     .creatorId(comment.getCreatorId())
-                    .creatorName(ANONYMOUS_POST_AND_COMMENT_CREATOR_NICKNAME)
+                    .creatorName(POST_CREATOR_NICKNAME)
                     .creatorProfileImageUrl(null)
                     .isPostOwner(comment.getIsPostOwner())
                     .content(comment.getContent())

--- a/src/main/java/space/space_spring/domain/post/application/service/strategy/AnonymousCommentProcessingStrategy.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/strategy/AnonymousCommentProcessingStrategy.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 public class AnonymousCommentProcessingStrategy implements CommentDetailProcessingStrategy {
 
+    private static final String ANONYMOUS_POST_AND_COMMENT_CREATOR_NICKNAME = "게시글 작성자";
     private static final String ANONYMOUS_COMMENT_CREATOR_NICKNAME = "익명 스페이서";
     private final Map<Long, String> anonymousNicknameMap = new HashMap<>();
     private int anonymousCount = 1;
@@ -18,6 +19,22 @@ public class AnonymousCommentProcessingStrategy implements CommentDetailProcessi
 
     @Override
     public CommentDetailView process(CommentDetailView comment) {
+        if (comment.getIsPostOwner()) {
+            return CommentDetailView.builder()
+                    .creatorId(comment.getCreatorId())
+                    .creatorName(ANONYMOUS_POST_AND_COMMENT_CREATOR_NICKNAME)
+                    .creatorProfileImageUrl(null)
+                    .isPostOwner(comment.getIsPostOwner())
+                    .content(comment.getContent())
+                    .createdAt(comment.getCreatedAt())
+                    .lastModifiedAt(comment.getLastModifiedAt())
+                    .likeCount(comment.getLikeCount())
+                    .isLiked(comment.getIsLiked())
+                    .isActiveComment(comment.getIsActiveComment())
+                    .isAnonymousComment(comment.getIsAnonymousComment())
+                    .build();
+        }
+
         Long creatorId = comment.getCreatorId();
         String nickname = anonymousNicknameMap.computeIfAbsent(creatorId,
                 id -> ANONYMOUS_COMMENT_CREATOR_NICKNAME + " " + anonymousCount++);


### PR DESCRIPTION
## 📝 요약
1. 스페이스 웹에서 익명 댓글 생성 시, 디스코드로 보내는 익명 댓글 작성자 닉네임 만드는 로직 수정
2. 게시글 상세 조회 시, 게시글 작성자가 익명 댓글을 단 경우 댓글 작성자의 닉네임을 "게시글 작성자" 로 보이도록 수정

이슈 번호 : #364 

## 🔖 변경 사항
<스페이스 웹에서의 익명 댓글 생성 api 수정>
1. CreateCommentService 에서 CommentCreatorQueryPort 을 호출하여 해당 게시글에 달린 익명 댓글들의 댓글 작성자 정보 전부 로드
2. 서비스 클래스에서 현재 익명 댓글 작성자에게 적절한 닉네임 부여 (ex. 익명 스페이서 n)
3. 이때 현재 익명 댓글 작성자가 게시글 작성자와 동일인물일 경우, 닉네임을 "게시글 작성자" 로 부여
4. 이 정보들을 CreateCommentInDiscordUseCase 로 전송 

<게시글 상세 조회 api 수정>
기존 코드에서는 익명 댓글 작성자가 해당 게시글의 작성자와 동일 인물임에도 "익명 스페이서 n" 으로 닉네임을 부여하였음
1. 위의 경우 "게시글 작성자"로 익명 댓글 작성자의 닉네임을 수정
2. 1의 요구사항을 충족하면서 다른 익명 댓글 작성자의 닉네임이 "익명 스페이서 1", "익명 스페이서 2" ,, 이런식으로 빠짐없이 순차적으로 부여되도록 AnonymousCommentProcessingStrategy 로직 수정

## ✅ 리뷰 요구사항
@drbug2000 CreateCommentCommand 의 createdAt, lastModifiedAt 의 값이 builder의 인자로 주어지지않는 경우 null 값을 가지게끔 코드를 수정했습니다.
이렇게 수정해도 문제없는지 pull 받아서 확인해주시면 감사하겠습니다!

## 📸 확인 방법 (선택)
<img width="720" alt="image" src="https://github.com/user-attachments/assets/56bdd728-3320-4fe8-9e22-05e85d1d7ca8" />

로컬 서버에서 스웨거로 익명 질문 생성 & 익명/비익명 댓글 생성한 결과입니다. 
dev 서버로 배포한 후, 여러명의 유저에 대해서 에타처럼 잘 작동하는지 확인해보면 될 거 같습니다. 

<img width="697" alt="image" src="https://github.com/user-attachments/assets/07e8231b-28e3-430d-ba23-33f40846490f" />

이건 수정한 게시글 상세 조회 api 의 스웨거 response 화면입니다
이거도 마찬가지로 dev 서버로 배포한 후, 여러명의 유저에 대해서 에타처럼 잘 작동하는지 확인해보면 될 거 같습니다.

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
