### PR TITLE
feat : 스페이스 전체 멤버 조회 api 개발

### DIFF
--- a/src/main/java/space/space_spring/domain/spaceMember/adapter/in/ReadAllSpaceMemberController.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/adapter/in/ReadAllSpaceMemberController.java
@@ -1,0 +1,28 @@
+package space.space_spring.domain.spaceMember.adapter.in;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import space.space_spring.domain.spaceMember.application.port.in.ReadSpaceMemberUseCase;
+import space.space_spring.global.common.response.BaseResponse;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "SpaceMember", description = "스페이스 멤버 관련 API")
+public class ReadAllSpaceMemberController {
+
+    private final ReadSpaceMemberUseCase readSpaceMemberUseCase;
+
+    @Operation(summary = "스페이스 전체 멤버 조회", description = """
+            
+            특정 스페이스에 속하는 전체 스페이스 멤버들의 정보를 조회합니다.
+            
+            """)
+    @GetMapping("/space/{spaceId}/all-member")
+    public BaseResponse<ResponseOfReadAllSpaceMember> showAllSpaceMembers(@PathVariable("spaceId") Long spaceId) {
+        return new BaseResponse<>(ResponseOfReadAllSpaceMember.of(readSpaceMemberUseCase.readAllSpaceMembers(spaceId)));
+    }
+}

--- a/src/main/java/space/space_spring/domain/spaceMember/adapter/in/ResponseOfReadAllSpaceMember.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/adapter/in/ResponseOfReadAllSpaceMember.java
@@ -1,0 +1,21 @@
+package space.space_spring.domain.spaceMember.adapter.in;
+
+import lombok.Builder;
+import lombok.Getter;
+import space.space_spring.domain.spaceMember.application.port.out.query.SpaceMemberDetail;
+
+import java.util.List;
+
+@Getter
+public class ResponseOfReadAllSpaceMember {
+
+    List<SpaceMemberDetail> spaceMemberDetails;
+
+    private ResponseOfReadAllSpaceMember(List<SpaceMemberDetail> spaceMemberDetails) {
+        this.spaceMemberDetails = spaceMemberDetails;
+    }
+
+    public static ResponseOfReadAllSpaceMember of(List<SpaceMemberDetail> spaceMemberDetails) {
+        return new ResponseOfReadAllSpaceMember(spaceMemberDetails);
+    }
+}

--- a/src/main/java/space/space_spring/domain/spaceMember/adapter/out/persistence/SpaceMemberQueryAdapter.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/adapter/out/persistence/SpaceMemberQueryAdapter.java
@@ -1,0 +1,34 @@
+package space.space_spring.domain.spaceMember.adapter.out.persistence;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import space.space_spring.domain.spaceMember.application.port.out.query.SpaceMemberDetail;
+import space.space_spring.domain.spaceMember.application.port.out.query.SpaceMemberQueryPort;
+import space.space_spring.domain.spaceMember.domian.QSpaceMemberJpaEntity;
+import space.space_spring.global.common.enumStatus.BaseStatusType;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SpaceMemberQueryAdapter implements SpaceMemberQueryPort {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<SpaceMemberDetail> loadSpaceMemberDetails(Long spaceId) {
+        QSpaceMemberJpaEntity spaceMember = QSpaceMemberJpaEntity.spaceMemberJpaEntity;
+        return queryFactory.select(
+                        Projections.constructor(SpaceMemberDetail.class,
+                                spaceMember.id,
+                                spaceMember.nickname,
+                                spaceMember.profileImageUrl,
+                                spaceMember.isManager))
+                .from(spaceMember)
+                .where(spaceMember.space.id.eq(spaceId)
+                        .and(spaceMember.status.eq(BaseStatusType.ACTIVE)))
+                .fetch();
+    }
+}

--- a/src/main/java/space/space_spring/domain/spaceMember/application/port/in/ReadSpaceMemberUseCase.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/application/port/in/ReadSpaceMemberUseCase.java
@@ -1,0 +1,10 @@
+package space.space_spring.domain.spaceMember.application.port.in;
+
+import space.space_spring.domain.spaceMember.application.port.out.query.SpaceMemberDetail;
+
+import java.util.List;
+
+public interface ReadSpaceMemberUseCase {
+
+    List<SpaceMemberDetail> readAllSpaceMembers(Long spaceId);
+}

--- a/src/main/java/space/space_spring/domain/spaceMember/application/port/out/query/SpaceMemberDetail.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/application/port/out/query/SpaceMemberDetail.java
@@ -1,0 +1,25 @@
+package space.space_spring.domain.spaceMember.application.port.out.query;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SpaceMemberDetail {
+
+    private Long spaceMemberId;
+
+    private String nickname;
+
+    private String profileImageUrl;
+
+    private Boolean isManager;
+
+    // QueryDsl을 위한 생성자
+    public SpaceMemberDetail(Long spaceMemberId, String nickname, String profileImageUrl, Boolean isManager) {
+        this.spaceMemberId = spaceMemberId;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.isManager = isManager;
+    }
+}

--- a/src/main/java/space/space_spring/domain/spaceMember/application/port/out/query/SpaceMemberQueryPort.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/application/port/out/query/SpaceMemberQueryPort.java
@@ -1,0 +1,8 @@
+package space.space_spring.domain.spaceMember.application.port.out.query;
+
+import java.util.List;
+
+public interface SpaceMemberQueryPort {
+
+    List<SpaceMemberDetail> loadSpaceMemberDetails(Long spaceId);
+}

--- a/src/main/java/space/space_spring/domain/spaceMember/application/service/ReadSpaceMemberService.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/application/service/ReadSpaceMemberService.java
@@ -1,0 +1,23 @@
+package space.space_spring.domain.spaceMember.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import space.space_spring.domain.spaceMember.application.port.in.ReadSpaceMemberUseCase;
+import space.space_spring.domain.spaceMember.application.port.out.query.SpaceMemberDetail;
+import space.space_spring.domain.spaceMember.application.port.out.query.SpaceMemberQueryPort;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReadSpaceMemberService implements ReadSpaceMemberUseCase {
+
+    private final SpaceMemberQueryPort spaceMemberQueryPort;
+
+    @Override
+    public List<SpaceMemberDetail> readAllSpaceMembers(Long spaceId) {
+        return spaceMemberQueryPort.loadSpaceMemberDetails(spaceId);
+    }
+}


### PR DESCRIPTION
## 📝 요약
특정 스페이스에 속하는 전체 멤버를 조회하는 api 개발

이슈 번호 : #369 

## 🔖 변경 사항
단순 조회여서 QueryPort가 반환하는 DTO인 SpaceMemberDetail 에 service, controller 모두 의존하도록 코드를 구현했습니다.
어차피 response 값이 변경될 경우 api 전체를 수정해야 하니까 하나의 model에 api의 모든 코드가 의존해도 괜찮지 않나 싶어서 이렇게 구현했습니다.
나름 CQRS 패턴으로 조회 로직을 구현했다고 봐주시면 될 듯 합니다.

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)
<img width="732" alt="image" src="https://github.com/user-attachments/assets/68afd690-365e-4496-8304-54618b647a4b" />
로컬 서버에서 포스트맨을 사용해 테스트 해봤습니당

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
