### PR TITLE
Feat/#357/게시판 페이징 처리

### DIFF
--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/readPostList/ReadPostListController.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/readPostList/ReadPostListController.java
@@ -3,6 +3,9 @@ package space.space_spring.domain.post.adapter.in.web.readPostList;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,15 +24,18 @@ public class ReadPostListController {
 
     @Operation(summary = "게시글 리스트 조회", description = """
             
-            스페이스 멤버가 게시판의 게시글 리스트를 조회합니다.
+            스페이스 멤버가 게시판의 게시글 리스트를 조회합니다.(무한 스크롤)
             
             """)
     @GetMapping("/space/{spaceId}/board/{boardId}/post")
     public BaseResponse<ResponseOfReadPostList> readPostList(
             @PathVariable Long spaceId,
             @PathVariable Long boardId,
-            @RequestParam(required = false) Long tagId) {
-        ListOfPostSummary postSummaries = readPostListUseCase.readPostList(boardId, tagId);
+            @RequestParam(required = false) Long tagId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        ListOfPostSummary postSummaries = readPostListUseCase.readPostList(boardId, tagId, pageable);
         return new BaseResponse<>(ResponseOfReadPostList.of(postSummaries));
     }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/readPostList/ReadPostListController.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/readPostList/ReadPostListController.java
@@ -34,7 +34,7 @@ public class ReadPostListController {
             @RequestParam(required = false) Long tagId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(page, size, Sort.by("postBase.createdAt").descending());
         ListOfPostSummary postSummaries = readPostListUseCase.readPostList(boardId, tagId, pageable);
         return new BaseResponse<>(ResponseOfReadPostList.of(postSummaries));
     }

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/readPostList/ResponseOfReadPostList.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/readPostList/ResponseOfReadPostList.java
@@ -11,13 +11,34 @@ public class ResponseOfReadPostList {
 
     private List<ResponseOfPostSummary> readPostList;
 
-    private ResponseOfReadPostList(List<PostSummary> readPostList) {
+    private int page;
+
+    private int size;
+
+    private long totalElements;
+
+    private int totalPages;
+
+    private Boolean isLast;
+
+    private ResponseOfReadPostList(List<PostSummary> readPostList, int page, int size, long totalElements, int totalPages, Boolean isLast) {
         this.readPostList = readPostList.stream()
                 .map(ResponseOfPostSummary::of)
                 .toList();
+        this.page = page;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.isLast = isLast;
     }
 
     public static ResponseOfReadPostList of(ListOfPostSummary list) {
-        return new ResponseOfReadPostList(list.getReadPostList());
+        return new ResponseOfReadPostList(
+                list.getReadPostList(),
+                list.getPage(),
+                list.getSize(),
+                list.getTotalElements(),
+                list.getTotalPages(),
+                list.getIsLast());
     }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -1,8 +1,9 @@
 package space.space_spring.domain.post.adapter.out.persistence.post;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 import space.space_spring.domain.post.adapter.out.persistence.board.BoardJpaEntity;
 import space.space_spring.domain.post.adapter.out.persistence.board.SpringDataBoardRepository;
 import space.space_spring.domain.post.adapter.out.persistence.postBase.PostBaseMapper;
@@ -64,7 +65,13 @@ public class PostPersistenceAdapter implements CreatePostPort, LoadPostPort, Upd
     }
 
     @Override
-    public List<Post> loadPostListByTagId(Long tagId) {
+    public Page<Post> loadPostListByBoardId(Long boardId, Pageable pageable) {
+        Page<PostJpaEntity> page = postRepository.findPostsByBoardIdPaged(boardId, BaseStatusType.ACTIVE, pageable);
+        return page.map(postMapper::toDomainEntity);
+    }
+
+    @Override
+    public Page<Post> loadPostListByTagId(Long tagId, Pageable pageable) {
         // 1. 태그에 해당하는 PostBaseJpaEntity 조회
         List<PostBaseJpaEntity> postBaseJpaEntities = postBaseRepository.findPostsByTagId(tagId, BaseStatusType.ACTIVE);
 
@@ -73,9 +80,9 @@ public class PostPersistenceAdapter implements CreatePostPort, LoadPostPort, Upd
                 .map(PostBaseJpaEntity::getId)
                 .toList();
 
-        List<PostJpaEntity> postJpaEntities = postRepository.findAllById(postBaseIds);
+        Page<PostJpaEntity> page = postRepository.findByPostBaseIdIn(postBaseIds, pageable);
 
-        return postJpaEntities.stream().map(postMapper::toDomainEntity).toList();
+        return page.map(postMapper::toDomainEntity);
 
     }
 

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/SpringDataPostRepository.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/SpringDataPostRepository.java
@@ -1,9 +1,12 @@
 package space.space_spring.domain.post.adapter.out.persistence.post;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import space.space_spring.domain.post.adapter.out.persistence.post.custom.PostRepositoryCustom;
+import space.space_spring.domain.post.domain.Post;
 import space.space_spring.global.common.enumStatus.BaseStatusType;
 
 import java.util.List;
@@ -16,11 +19,23 @@ public interface SpringDataPostRepository extends JpaRepository<PostJpaEntity, L
             "AND pb.status = :status")
     List<PostJpaEntity> findPostsByBoardId(@Param("boardId") Long boardId,
                                            @Param("status") BaseStatusType status);
+
+    @Query(value = "SELECT p FROM PostJpaEntity p " +
+            "JOIN FETCH p.postBase pb " +
+            "WHERE pb.board.id = :boardId " +
+            "AND pb.status = :status",
+            countQuery = "SELECT COUNT(p) FROM PostJpaEntity p JOIN p.postBase pb WHERE pb.board.id = :boardId AND pb.status = :status")
+    Page<PostJpaEntity> findPostsByBoardIdPaged(@Param("boardId") Long boardId,
+                                               @Param("status") BaseStatusType status,
+                                               Pageable pageable);
+
+    Page<PostJpaEntity> findByPostBaseIdIn(List<Long> postBaseIds, Pageable pageable);
+
+
     @Query("SELECT p FROM PostJpaEntity p " +
             "JOIN FETCH p.postBase pb " +
             "WHERE pb.discordId = :discordId " +
             "AND pb.status = :status")
     PostJpaEntity findByDiscordId(@Param("discordId") Long discordId,
                                       @Param("status") BaseStatusType status);
-
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/in/readPostList/ListOfPostSummary.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/readPostList/ListOfPostSummary.java
@@ -1,6 +1,8 @@
 package space.space_spring.domain.post.application.port.in.readPostList;
 
 import lombok.Getter;
+import org.springframework.data.domain.Page;
+import space.space_spring.domain.post.domain.Post;
 
 import java.util.List;
 
@@ -9,11 +11,32 @@ public class ListOfPostSummary {
 
     private List<PostSummary> readPostList;
 
-    private ListOfPostSummary(List<PostSummary> readPostList) {
+    private int page;
+
+    private int size;
+
+    private long totalElements;
+
+    private int totalPages;
+
+    private Boolean isLast;
+
+    private ListOfPostSummary(List<PostSummary> readPostList, int page, int size, long totalElements, int totalPages, Boolean isLast) {
         this.readPostList = readPostList;
+        this.page = page;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.isLast = isLast;
     }
 
-    public static ListOfPostSummary of(List<PostSummary> readPostList) {
-        return new ListOfPostSummary(readPostList);
+    public static ListOfPostSummary of(Page<Post> postPage, List<PostSummary> summaries) {
+        return new ListOfPostSummary(
+                summaries,
+                postPage.getNumber(),
+                postPage.getSize(),
+                postPage.getTotalElements(),
+                postPage.getTotalPages(),
+                postPage.isLast());
     }
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/in/readPostList/ReadPostListUseCase.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/readPostList/ReadPostListUseCase.java
@@ -1,6 +1,8 @@
 package space.space_spring.domain.post.application.port.in.readPostList;
 
+import org.springframework.data.domain.Pageable;
+
 public interface ReadPostListUseCase {
 
-    ListOfPostSummary readPostList(Long boardId, Long tagId);
+    ListOfPostSummary readPostList(Long boardId, Long tagId, Pageable pageable);
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/out/LoadPostPort.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/out/LoadPostPort.java
@@ -1,5 +1,7 @@
 package space.space_spring.domain.post.application.port.out;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import space.space_spring.domain.post.domain.Post;
 
 import java.util.List;
@@ -9,7 +11,9 @@ public interface LoadPostPort {
 
     List<Post> loadPostListByBoardId(Long boardId);
 
-    List<Post> loadPostListByTagId(Long tagId);
+    Page<Post> loadPostListByBoardId(Long boardId, Pageable pageable);
+
+    Page<Post> loadPostListByTagId(Long tagId, Pageable pageable);
 
     Post loadById(Long postId);
 


### PR DESCRIPTION
## 📝 요약

이슈 번호 : #357

## 🔖 변경 사항
게시글 리스트 조회 시, 무한 페이징 로직 추가
Pageable 객체로 page, size 정보를 받아옵니다. page default값은 0, size default 값은 20입니다.
응답에 현재 페이지, 페이지당 개수, 전체 게시글 수, 전체 페이지 수, 마지막 페이지 여부를 포함하여 페이징 정보를 추가했습니다.

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)
![image](https://github.com/user-attachments/assets/40d1c61b-75ea-49c4-a4c9-8f282a6cdcba)
로컬 테스트 완료했습니다
<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
