### PR TITLE
Fix/#400: 행사 참여자 조회 및 홈 조회 미리보기 이슈

### DIFF
--- a/src/main/java/space/space_spring/domain/event/adapter/out/persistence/EventParticipantPersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/event/adapter/out/persistence/EventParticipantPersistenceAdapter.java
@@ -30,7 +30,7 @@ public class EventParticipantPersistenceAdapter implements LoadEventParticipantP
     public EventParticipants loadByEventId(Long eventId) {
         EventJpaEntity eventJpaEntity = eventRepository.findByIdAndStatus(eventId, ACTIVE).orElseThrow(
                 () -> new CustomException(EVENT_NOT_FOUND));
-        List<EventParticipantJpaEntity> eventParticipantJpaEntities = eventParticipantRepository.findByEventAndStatusOrderByCreatedAtDesc(eventJpaEntity, ACTIVE);
+        List<EventParticipantJpaEntity> eventParticipantJpaEntities = eventParticipantRepository.findByEventAndStatusOrderByUpdatedAtDesc(eventJpaEntity, ACTIVE);
 
         List<EventParticipant> participants = new ArrayList<>();
         for (EventParticipantJpaEntity e : eventParticipantJpaEntities) {

--- a/src/main/java/space/space_spring/domain/event/adapter/out/persistence/custom/EventParticipantRepositoryCustom.java
+++ b/src/main/java/space/space_spring/domain/event/adapter/out/persistence/custom/EventParticipantRepositoryCustom.java
@@ -8,7 +8,7 @@ import space.space_spring.global.common.enumStatus.BaseStatusType;
 
 public interface EventParticipantRepositoryCustom {
 
-    List<EventParticipantJpaEntity> findByEventAndStatusOrderByCreatedAtDesc(EventJpaEntity event, BaseStatusType status);
+    List<EventParticipantJpaEntity> findByEventAndStatusOrderByUpdatedAtDesc(EventJpaEntity event, BaseStatusType status);
 
     void deleteAllByEvent(EventJpaEntity event);
 

--- a/src/main/java/space/space_spring/domain/event/adapter/out/persistence/custom/EventParticipantRepositoryImpl.java
+++ b/src/main/java/space/space_spring/domain/event/adapter/out/persistence/custom/EventParticipantRepositoryImpl.java
@@ -17,12 +17,12 @@ public class EventParticipantRepositoryImpl implements EventParticipantRepositor
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<EventParticipantJpaEntity> findByEventAndStatusOrderByCreatedAtDesc(EventJpaEntity event,
+    public List<EventParticipantJpaEntity> findByEventAndStatusOrderByUpdatedAtDesc(EventJpaEntity event,
                                                                                     BaseStatusType status) {
         return jpaQueryFactory.selectFrom(eventParticipantJpaEntity)
                 .where(eventParticipantJpaEntity.event.id.eq(event.getId())
                         .and(eventParticipantJpaEntity.status.eq(ACTIVE)))
-                .orderBy(eventParticipantJpaEntity.createdAt.desc())
+                .orderBy(eventParticipantJpaEntity.lastModifiedAt.desc())
                 .fetch();
     }
 

--- a/src/main/java/space/space_spring/domain/event/application/service/ReadEventParticipantService.java
+++ b/src/main/java/space/space_spring/domain/event/application/service/ReadEventParticipantService.java
@@ -25,7 +25,7 @@ public class ReadEventParticipantService implements ReadEventParticipantUseCase 
         if (participants.isEmpty()) return EventParticipantInfos.createEmpty();
 
         List<Long> participantIds = participants.getSpaceMemberIds();
-        SpaceMembers spaceMemberInfos = SpaceMembers.of(loadSpaceMemberPort.loadAllById(participantIds));
+        SpaceMembers spaceMemberInfos = SpaceMembers.of(loadSpaceMemberPort.loadAllByIdInOrder(participantIds));
 
         return EventParticipantInfos.create(spaceMemberInfos);
     }

--- a/src/main/java/space/space_spring/domain/home/adapter/in/web/ReadHomeResponse.java
+++ b/src/main/java/space/space_spring/domain/home/adapter/in/web/ReadHomeResponse.java
@@ -25,5 +25,6 @@ public class ReadHomeResponse {
         this.memberCnt = readHomeResult.memberCnt;
         this.img = readHomeResult.img;
         this.notices = readHomeResult.notices;
+        this.subscriptions = readHomeResult.subscriptions;
     }
 }

--- a/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
+++ b/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
@@ -79,12 +79,18 @@ public class ReadHomeService implements ReadHomeUseCase {
             Optional<Tag> tag = loadTagPort.loadByBoardId(board.getId());
 
             // 각 게시판에서 제일 최신 게시물 정보 가져오기
+            Optional<Post> latestPost;
             String postTitle = "";
             String tagName = "";
             if (tag.isPresent()) {
                 tagName = tag.get().getTagName();
-                Optional<Post> latestPost = loadPostPort.loadLatestPostByBoardIdAndTagId(board.getId(), tag.get().getId());
-                postTitle = latestPost.get().getTitle();
+                latestPost = loadPostPort.loadLatestPostByBoardIdAndTagId(board.getId(), tag.get().getId());
+                if (latestPost.isPresent()) postTitle = latestPost.get().getTitle();
+            } else {
+                latestPost = loadPostPort.loadLatestPostsByBoardIds(List.of(board.getId()), 1)
+                        .stream()
+                        .findFirst();
+                if (latestPost.isPresent()) postTitle = latestPost.get().getTitle();
             }
 
             subscriptions.add(new SubscriptionSummary(board.getId(), board.getBoardName(), postTitle, tagName));

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/custom/PostRepositoryImpl.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/custom/PostRepositoryImpl.java
@@ -33,15 +33,16 @@ public class PostRepositoryImpl implements PostRepositoryCustom{
 
     @Override
     public Optional<PostJpaEntity> findLatestByBoardIdAndTagId(Long boardId, Long tagId) {
-         return Optional.ofNullable(jpaQueryFactory.selectFrom(postJpaEntity)
-                 .join(postJpaEntity.postBase, postBaseJpaEntity)
-                 .join(postBaseJpaEntity.board, boardJpaEntity)
-                 .where(
-                         boardJpaEntity.id.eq(boardId), // 게시판 ID 조건
-                         tagJpaEntity.id.eq(tagId), // 태그 ID 조건
-                         postJpaEntity.postBase.status.eq(ACTIVE)
-                 )
-                 .orderBy(postJpaEntity.postBase.createdAt.desc()) // 최신 글 기준으로 정렬
-                 .fetchFirst());
+        return Optional.ofNullable(jpaQueryFactory.selectFrom(postJpaEntity)
+                .join(postJpaEntity.postBase, postBaseJpaEntity)
+                .join(postBaseJpaEntity.board, boardJpaEntity)
+                .join(tagJpaEntity).on(tagJpaEntity.board.eq(boardJpaEntity))
+                .where(
+                        boardJpaEntity.id.eq(boardId),
+                        tagJpaEntity.id.eq(tagId),
+                        postJpaEntity.postBase.status.eq(ACTIVE)
+                )
+                .orderBy(postJpaEntity.postBase.createdAt.desc())
+                .fetchFirst());
     }
 }

--- a/src/main/java/space/space_spring/domain/spaceMember/adapter/out/persistence/SpaceMemberPersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/adapter/out/persistence/SpaceMemberPersistenceAdapter.java
@@ -154,6 +154,14 @@ public class SpaceMemberPersistenceAdapter
     }
 
     @Override
+    public List<SpaceMember> loadAllByIdInOrder(List<Long> ids) {
+        List<SpaceMemberJpaEntity> allById = spaceMemberRepository.findAllByIdInOrder(ids);
+
+        return allById.stream().map(spaceMemberMapper::toDomainEntity)
+                .toList();
+    }
+
+    @Override
     public boolean delete(Long spaceId){
         //ToDo change to soft delete
         //spaceMemberRepository.delete();

--- a/src/main/java/space/space_spring/domain/spaceMember/adapter/out/persistence/custom/SpaceMemberRepositoryCustom.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/adapter/out/persistence/custom/SpaceMemberRepositoryCustom.java
@@ -1,8 +1,11 @@
 package space.space_spring.domain.spaceMember.adapter.out.persistence.custom;
 
+import java.util.List;
 import java.util.Optional;
 import space.space_spring.domain.spaceMember.domian.SpaceMemberJpaEntity;
 
 public interface SpaceMemberRepositoryCustom {
     Optional<SpaceMemberJpaEntity> findDefaultSpaceMember(Long userId, String defaultSpaceName);
+
+    List<SpaceMemberJpaEntity> findAllByIdInOrder(List<Long> ids);
 }

--- a/src/main/java/space/space_spring/domain/spaceMember/adapter/out/persistence/custom/SpaceMemberRepositoryImpl.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/adapter/out/persistence/custom/SpaceMemberRepositoryImpl.java
@@ -5,7 +5,9 @@ import static space.space_spring.domain.spaceMember.domian.QSpaceMemberJpaEntity
 import static space.space_spring.global.common.enumStatus.BaseStatusType.ACTIVE;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import space.space_spring.domain.spaceMember.domian.SpaceMemberJpaEntity;
 
@@ -26,5 +28,18 @@ public class SpaceMemberRepositoryImpl implements SpaceMemberRepositoryCustom {
                         spaceJpaEntity.status.eq(ACTIVE)
                 )
                 .fetchOne());
+    }
+
+    @Override
+    public List<SpaceMemberJpaEntity> findAllByIdInOrder(List<Long> ids) {
+        List<SpaceMemberJpaEntity> members = jpaQueryFactory.selectFrom(spaceMemberJpaEntity)
+                .where(spaceMemberJpaEntity.id.in(ids))
+                .fetch();
+
+        // ID 순서에 맞게 정렬
+        return ids.stream()
+                .map(id -> members.stream().filter(member -> member.getId().equals(id)).findFirst().orElse(null))
+                .filter(member -> member != null && member.isActive())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/space/space_spring/domain/spaceMember/application/port/out/LoadSpaceMemberPort.java
+++ b/src/main/java/space/space_spring/domain/spaceMember/application/port/out/LoadSpaceMemberPort.java
@@ -16,4 +16,6 @@ public interface LoadSpaceMemberPort {
     SpaceMember loadByDiscord(Long spaceDiscordId , Long spaceMemberDiscordId);
 
     Optional<SpaceMember> loadDefaultSpaceMember(Long userId, String defaultSpaceName);
+
+    List<SpaceMember> loadAllByIdInOrder(List<Long> ids);
 }


### PR DESCRIPTION
## 📝 요약

- resolved #400 

## 🔖 변경 사항
- 홈 조회 시 구독한 게시판 중 태그가 없는 경우에 대해 최신 게시글 미리보기 구현
- 행사 참여자 조회 시 최신순 정렬 이슈 해결 : 참여자를 최신순으로 불러오는 것은 잘 동작하고 있었으나, **최신순으로 불러온 참여자들의 space member 정보를 불러오는 과정에서 최신순이 적용되지 않고 있었습니다.** 따라서 space member의 adapter에 파라미터로 넘긴 id 리스트의 순서대로 space member를 불러오는 메소드를 추가했습니다.

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)
- 홈 조회 테스트
<img width="1399" alt="스크린샷 2025-03-27 21 42 23" src="https://github.com/user-attachments/assets/ebbce29e-40be-49ed-af5d-3b4fe97fd0a5" />

- 행사 참여자 조회
<img width="1394" alt="스크린샷 2025-03-27 22 34 32" src="https://github.com/user-attachments/assets/430a8bf3-ee6a-4c8e-a36a-3b7bd53406b5" />
<img width="990" alt="스크린샷 2025-03-27 22 34 52" src="https://github.com/user-attachments/assets/76656a55-5743-41ad-a0af-5fa1fb23091a" />

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
