### PR TITLE
[fix] 디스코드 포럼 게시물 수정 버그 수정 

### DIFF
--- a/src/main/java/space/space_spring/domain/discord/adapter/in/discord/MessageUpdateEventListener.java
+++ b/src/main/java/space/space_spring/domain/discord/adapter/in/discord/MessageUpdateEventListener.java
@@ -68,7 +68,7 @@ public class MessageUpdateEventListener extends ListenerAdapter {
     }
 
     private boolean isComment(MessageUpdateEvent event){
-        return event.isFromThread()&&event.getChannel().getId().equals(event.getMessage().getId());
+        return event.isFromThread()&&!event.getChannel().getId().equals(event.getMessage().getId());
     }
 
     private boolean isAvailableChannelType(MessageChannelUnion channel){


### PR DESCRIPTION
포럼 게시물 수정이 댓글 수정으로 처리 되던 오류를 수정하였습니다

## 📝 요약

- 이슈 번호 : #405

포럼 게시물을 수정하면, comment 수정 flow를 호출하는 오류를 수정하였습니다

## 🔖 변경 사항

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
