### PR TITLE
refactor : 이미 송금 완료한 정산에 대해 api 요청이 올 경우 Exception throw

### DIFF
--- a/src/main/java/space/space_spring/domain/discord/adapter/in/discord/ButtonInteraction/PayComplete/PayCompleteButtonProcessor.java
+++ b/src/main/java/space/space_spring/domain/discord/adapter/in/discord/ButtonInteraction/PayComplete/PayCompleteButtonProcessor.java
@@ -9,6 +9,10 @@ import space.space_spring.domain.pay.application.port.out.LoadPayRequestPort;
 import space.space_spring.domain.pay.application.port.out.LoadPayRequestTargetPort;
 import space.space_spring.domain.spaceMember.application.port.out.LoadSpaceMemberPort;
 import space.space_spring.domain.spaceMember.domian.SpaceMember;
+import space.space_spring.global.exception.CustomException;
+
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.ALREADY_COMPLETE_PAY_REQUEST_TARGET;
+
 @Component
 @RequiredArgsConstructor
 public class PayCompleteButtonProcessor implements ButtonInteractionProcessor {
@@ -29,14 +33,22 @@ public class PayCompleteButtonProcessor implements ButtonInteractionProcessor {
         Long guildId = event.getGuild().getIdLong();
         SpaceMember spaceMember = loadSpaceMemberPort.loadByDiscord(guildId,event.getMember().getIdLong());
         Long spaceMemberId = spaceMember.getId();
-        completePayUseCase.completeForRequestedPay(
-                spaceMemberId,
-                loadPayRequestTargetPort.loadByTargetMemberId(spaceMemberId).stream()
-                        .filter(payTarget-> {
-                            return loadPayRequestPort.loadById(payTarget.getPayRequestId()).getDiscordMessageId().equals(payRequestDiscordId);
-                        }).findFirst().orElseThrow().getId());
-        event.reply("정산 완료 처리 되었습니다")
-                .setEphemeral(true)
-                .queue();
+
+        try {
+            completePayUseCase.completeForRequestedPay(
+                    spaceMemberId,
+                    loadPayRequestTargetPort.loadByTargetMemberId(spaceMemberId).stream()
+                            .filter(payTarget-> {
+                                return loadPayRequestPort.loadById(payTarget.getPayRequestId()).getDiscordMessageId().equals(payRequestDiscordId);
+                            }).findFirst().orElseThrow().getId());
+            event.reply("정산 완료 처리 되었습니다")
+                    .setEphemeral(true)
+                    .queue();
+        } catch (CustomException e) {
+            if (e.getMessage().equals(ALREADY_COMPLETE_PAY_REQUEST_TARGET.getMessage())) {
+                // 상준님 구현 부탁드립니다!
+
+            }
+        }
     }
 }

--- a/src/main/java/space/space_spring/domain/pay/application/service/CompletePayService.java
+++ b/src/main/java/space/space_spring/domain/pay/application/service/CompletePayService.java
@@ -9,6 +9,7 @@ import space.space_spring.domain.pay.application.port.out.UpdatePayPort;
 import space.space_spring.domain.pay.domain.PayRequestTarget;
 import space.space_spring.global.exception.CustomException;
 
+import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.ALREADY_COMPLETE_PAY_REQUEST_TARGET;
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.PAY_REQUEST_TARGET_MISMATCH;
 
 @Service
@@ -23,6 +24,10 @@ public class CompletePayService implements CompletePayUseCase {
     public void completeForRequestedPay(Long targetMemberId, Long payRequestTargetId) {
         // access token에 포함된 spaceMemberId 가 정산 타겟 유저가 맞는지 확인
         PayRequestTarget payRequestTarget = loadPayRequestTargetPort.loadById(payRequestTargetId);
+
+        if (payRequestTarget.isComplete()) {
+            throw new CustomException(ALREADY_COMPLETE_PAY_REQUEST_TARGET);
+        }
 
         if (!payRequestTarget.isSameTargetMember(targetMemberId)) {
             throw new CustomException(PAY_REQUEST_TARGET_MISMATCH);

--- a/src/main/java/space/space_spring/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/space/space_spring/global/common/response/status/BaseExceptionResponseStatus.java
@@ -139,7 +139,10 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     LIKE_NOT_FOUND(11019, HttpStatus.NOT_FOUND, "존재하지 않는 좋아요 입니다."),
 
     INVALID_CHANGE_LIKE_STATE_REQUEST(11020, HttpStatus.BAD_REQUEST, "좋아요 on/off 요청에서 잘못된 값이 존재합니다."),
-    TAGS_IS_WORNG(11021,HttpStatus.CONFLICT,"생성 중인 tag 들의 board가 같지 않습니다"),
+    NOTICE_NOT_FOUND(11021, HttpStatus.NOT_FOUND, "공지사항 게시판을 찾을 수 없습니다."),
+    TAGS_IS_WORNG(11022,HttpStatus.CONFLICT,"생성 중인 tag 들의 board가 같지 않습니다"),
+
+
     /**
      * 12000 : Pay 오류
      */
@@ -158,8 +161,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     PAY_REQUEST_TARGET_MISMATCH(12011, HttpStatus.BAD_REQUEST, "정산 요청 대상자가 본인과 일치하지 않습니다."),
     PAY_REQUEST_CREATOR_MISMATCH(12012, HttpStatus.BAD_REQUEST, "정산 생성자가 본인과 일치하지 않습니다."),
 
+    ALREADY_COMPLETE_PAY_REQUEST_TARGET(12013, HttpStatus.BAD_REQUEST, "해당 정산 요청 대상자는 이미 송금 완료 하였습니다."),
 
-    NOTICE_NOT_FOUND(11020, HttpStatus.NOT_FOUND, "공지사항 게시판을 찾을 수 없습니다."),
 
     /**
      * 13000 : Event 오류


### PR DESCRIPTION
## 📝 요약
resolved : #408 

## 🔖 변경 사항
- 이미 송금 완료된 정산 요청에 대해 정산 완료 처리 api 요청이 들어올 경우 HttpStatus.BAD_REQUEST exception을 throw 하도록 서비스 클래스 코드 수정
- @drbug2000 상준님 디스코드에서 정산 완료 버튼 처리하는 로직에 exception catch 할 경우 "이미 완료 처리된 정산입니다." 와 같은 적당한 메시지를 띄워주시면 감사하겠습니다!

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
