### PR TITLE
Feat : 이미 완료한 정산에 대해 디스코드에서 "정산 완료" 버튼 누르는 경우, 메시지 띄우는 기능 추가

### DIFF
--- a/src/main/java/space/space_spring/domain/discord/adapter/in/discord/ButtonInteraction/PayComplete/PayCompleteButtonProcessor.java
+++ b/src/main/java/space/space_spring/domain/discord/adapter/in/discord/ButtonInteraction/PayComplete/PayCompleteButtonProcessor.java
@@ -1,6 +1,7 @@
 package space.space_spring.domain.discord.adapter.in.discord.ButtonInteraction.PayComplete;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import org.springframework.stereotype.Component;
 import space.space_spring.domain.discord.adapter.in.discord.ButtonInteraction.ButtonInteractionProcessor;
@@ -15,6 +16,7 @@ import static space.space_spring.global.common.response.status.BaseExceptionResp
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class PayCompleteButtonProcessor implements ButtonInteractionProcessor {
     private final CompletePayUseCase completePayUseCase;
     private final LoadPayRequestTargetPort loadPayRequestTargetPort;
@@ -41,14 +43,18 @@ public class PayCompleteButtonProcessor implements ButtonInteractionProcessor {
                             .filter(payTarget-> {
                                 return loadPayRequestPort.loadById(payTarget.getPayRequestId()).getDiscordMessageId().equals(payRequestDiscordId);
                             }).findFirst().orElseThrow().getId());
-            event.reply("정산 완료 처리 되었습니다")
-                    .setEphemeral(true)
-                    .queue();
+
         } catch (CustomException e) {
             if (e.getMessage().equals(ALREADY_COMPLETE_PAY_REQUEST_TARGET.getMessage())) {
-                // 상준님 구현 부탁드립니다!
+                event.reply("이미 정산 완료 처리 하셨습니다").setEphemeral(true).queue();
 
+                return;
             }
+            log.error("pay complete in discord error:"+e.getMessage());
+            throw e;
         }
+        event.reply("정산 완료 처리 되었습니다")
+                .setEphemeral(true)
+                .queue();
     }
 }


### PR DESCRIPTION
## 📝 요약
resolved : #408 

## 🔖 변경 사항
@drbug2000 님이 디스코드에서 메시지 띄우는 코드 추가해주셨습니다.

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/dd2e8347-4085-4ee1-ac84-bae462fa556c" />

-> 로컬 서버 실행 & 스웨거로 정산 완료 처리한 정산 요청에 대해서 디스코드에서 정산 완료 버튼을 누를 경우, 위 화면처럼 보입니다

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
