### PR TITLE
Hotfix: 공지사항이 없을 때 빈 리스트 반환

### DIFF
--- a/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
+++ b/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
@@ -56,20 +56,19 @@ public class ReadHomeService implements ReadHomeUseCase {
         loadBoardPort.loadByType(NOTICE).forEach(board -> noticeBoardIds.add(board.getId()));
         loadBoardPort.loadByType(SEASON_NOTICE).forEach(board -> noticeBoardIds.add(board.getId()));
 
+        List<NoticeSummary> notices = new ArrayList<>();
         if (!noticeBoardIds.isEmpty()) {
             // 최신순 3개의 공지사항만 가져오기
             List<Post> noticePosts = loadPostPort.loadLatestPostsByBoardIds(noticeBoardIds, 3);
 
-            List<NoticeSummary> notices = new ArrayList<>();
             for (Post post : noticePosts) {
                 notices.add(new NoticeSummary(
                         post.getContent().getValue(),
                         ConvertCreatedDate.setCreatedDate(post.getBaseInfo().getCreatedAt())
                 ));
             }
-
-            result.addNotice(notices);
         }
+        result.addNotice(notices);
 
         // 구독한 게시판 가져오기
         List<SubscriptionSummary> subscriptions = new ArrayList<>();


### PR DESCRIPTION
## 📝 요약

홈 조회 시 공지사항 게시판이 없을 때 null을 반환하던 기존 코드에서 빈 리스트를 반환하는 것으로 수정

## 🔖 변경 사항

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)
<img width="1401" alt="image" src="https://github.com/user-attachments/assets/50249716-3412-478b-a804-07cd79a61742" />

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
