### PR TITLE
Hotfix/#428/완료된 정산 구분 로직

### DIFF
--- a/src/main/java/space/space_spring/domain/pay/application/service/ReadPayRequestListService.java
+++ b/src/main/java/space/space_spring/domain/pay/application/service/ReadPayRequestListService.java
@@ -20,7 +20,6 @@ import space.space_spring.global.util.NaturalNumber;
 import java.util.ArrayList;
 import java.util.List;
 
-import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.DATABASE_ERROR;
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.THIS_PAY_REQUEST_HAS_NOT_TARGETS;
 
 @Service
@@ -50,44 +49,34 @@ public class ReadPayRequestListService implements ReadPayRequestListUseCase {
     private void processPayRequest(PayRequest payRequest, List<InfoOfPayRequest> infosOfComplete, List<InfoOfPayRequest> infosOfInComplete) {
         try {
             CurrentPayRequestState currentState = loadCurrentPayRequestStateUseCase.loadCurrentPayRequestState(payRequest.getId());
-            Money receivedAmount = currentState.getReceivedAmount();
-            NaturalNumber sendCompleteTargetNum = currentState.getSendCompleteTargetNum();
-
-            // 완료 여부 체크 (두 조건이 모두 충족되어야 완료로 판단)
-            boolean isComplete = checkCompletionStatus(payRequest, receivedAmount, sendCompleteTargetNum);
-
-            InfoOfPayRequest info = createInfoOfPayRequest(payRequest, receivedAmount, sendCompleteTargetNum);
-
-            if (isComplete) {
-                infosOfComplete.add(info);
-            } else {
-                infosOfInComplete.add(info);
-            }
+            boolean isComplete = payRequest.isEqualToTotalTargetNum(currentState.getSendCompleteTargetNum());         // 완료된 정산 == 모든 정산 타겟들이 송금 완료하였다
+            InfoOfPayRequest info = createInfo(payRequest, currentState, isComplete);
+            addInfoToProperList(isComplete, info, infosOfComplete, infosOfInComplete);
         } catch (IllegalStateException e) {
             log.error("정산 대상 목록 로드 실패 - 현재 payRequestId: {}", payRequest.getId(), e);
             throw new CustomException(THIS_PAY_REQUEST_HAS_NOT_TARGETS);
         }
     }
 
-    private boolean checkCompletionStatus(PayRequest payRequest, Money receivedAmount, NaturalNumber sendCompleteTargetNum) {
-        boolean isAmountComplete = payRequest.isEqualToTotalAmount(receivedAmount);
-        boolean isTargetComplete = payRequest.isEqualToTotalTargetNum(sendCompleteTargetNum);
+    private InfoOfPayRequest createInfo(PayRequest payRequest, CurrentPayRequestState currentState, boolean isComplete) {
+        // 나머지 금액이 있을 수 있으므로 완료된 정산에서의 receivedAmount = payRequest.totalAmount 로 설정
+        Money calculatedSumOfAmount = isComplete ? payRequest.getTotalAmount() : currentState.getReceivedAmount();
 
-        if (isAmountComplete ^ isTargetComplete) {      // XOR: 한쪽만 true인 경우
-            log.error("DB 에러 - 불일치된 상태 (payRequestId: {}) - totalAmount: {}, receivedAmount: {}, totalTargetNum: {}, sendCompleteTargetNum: {}",
-                    payRequest.getId(), payRequest.getTotalAmount().getAmount(), receivedAmount.getAmount(), payRequest.getTotalTargetNum().getNumber(), sendCompleteTargetNum.getNumber());
-            throw new CustomException(DATABASE_ERROR);
-        }
-        return isAmountComplete && isTargetComplete;
-    }
-
-    private InfoOfPayRequest createInfoOfPayRequest(PayRequest payRequest, Money receivedAmount, NaturalNumber sendCompleteTargetNum) {
         return InfoOfPayRequest.of(
                 payRequest.getId(),
                 payRequest.getTotalAmount(),
-                receivedAmount,
+                calculatedSumOfAmount,
                 payRequest.getTotalTargetNum(),
-                sendCompleteTargetNum
+                currentState.getSendCompleteTargetNum()
         );
     }
+
+    private void addInfoToProperList(boolean isComplete, InfoOfPayRequest info, List<InfoOfPayRequest> infosOfComplete, List<InfoOfPayRequest> infosOfInComplete) {
+        if (isComplete) {
+            infosOfComplete.add(info);
+        } else {
+            infosOfInComplete.add(info);
+        }
+    }
+
 }

--- a/src/test/java/space/space_spring/domain/pay/application/service/ReadPayRequestListServiceTest.java
+++ b/src/test/java/space/space_spring/domain/pay/application/service/ReadPayRequestListServiceTest.java
@@ -140,36 +140,4 @@ class ReadPayRequestListServiceTest {
         assertThat(result.getCompletePayRequestList()).isEmpty();
         assertThat(result.getInCompletePayRequestList()).isEmpty();
     }
-
-    @Test
-    @DisplayName("불일치된 정산 상태인 경우, 데이터 베이스 예외 메시지를 던진다.")
-    void readPayRequestList_inconsistentState1() throws Exception {
-        //given
-        // [송금완료한 금액 == 정산 요청 총 금액 But 송금완료한 사람 != 정산 요청 총 대상 수] 인 경우
-        PayRequest payRequest = PayRequest.create(1L, seongjunId, 1L, Money.of(10000), NaturalNumber.of(3), Bank.of("우리은행", "111-111"), PayType.EQUAL_SPLIT, BaseInfo.ofEmpty());
-        Mockito.when(loadPayRequestPort.loadByPayCreatorId(seongjunId)).thenReturn(List.of(payRequest));
-        Mockito.when(loadCurrentPayRequestStateUseCase.loadCurrentPayRequestState(1L))
-                .thenReturn(CurrentPayRequestState.of(Money.of(10000), NaturalNumber.of(1)));
-
-        //when //then
-        assertThatThrownBy(() -> readPayRequestListService.readPayRequestList(seongjunId))
-                .isInstanceOf(CustomException.class)
-                .hasMessageContaining(DATABASE_ERROR.getMessage());
-    }
-
-    @Test
-    @DisplayName("불일치된 정산 상태인 경우, 데이터 베이스 예외 메시지를 던진다.")
-    void readPayRequestList_inconsistentState2() throws Exception {
-        //given
-        // [송금완료한 금액 != 정산 요청 총 금액 But 송금완료한 사람 == 정산 요청 총 대상 수] 인 경우
-        PayRequest payRequest = PayRequest.create(1L, seongjunId, 1L, Money.of(10000), NaturalNumber.of(3), Bank.of("우리은행", "111-111"), PayType.EQUAL_SPLIT, BaseInfo.ofEmpty());
-        Mockito.when(loadPayRequestPort.loadByPayCreatorId(seongjunId)).thenReturn(List.of(payRequest));
-        Mockito.when(loadCurrentPayRequestStateUseCase.loadCurrentPayRequestState(1L))
-                .thenReturn(CurrentPayRequestState.of(Money.of(5000), NaturalNumber.of(3)));
-
-        //when //then
-        assertThatThrownBy(() -> readPayRequestListService.readPayRequestList(seongjunId))
-                .isInstanceOf(CustomException.class)
-                .hasMessageContaining(DATABASE_ERROR.getMessage());
-    }
 }


### PR DESCRIPTION
## 📝 요약
resolved : #428 

## 🔖 변경 사항
<ReadPayRequestListService 코드 수정>
- 완료된 정산을 구분하는 로직 수정
- 기존 로직 : 정산 대상의 총 인원 수 == 돈 낸 사람 수 && 정산 요청 시 총 금액 == 정산 대상들이 낸 돈의 합
- 수정된 로직 : 정산 대상의 총 인원 수 == 돈 낸 사람 수
-> 기존 로직에서는 1/n 정산에서 발생할 수 있는 나머지 금액(ex 10000원을 3명이서 정산시 1원 나머지 금액 발생) 이 비어서, exception을 throw 하고 있었습니다

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
