### PR TITLE
Hotfix: 홈 조회 시 게시물 제목 반환

### DIFF
--- a/src/main/java/space/space_spring/domain/home/adapter/in/web/NoticeSummary.java
+++ b/src/main/java/space/space_spring/domain/home/adapter/in/web/NoticeSummary.java
@@ -11,7 +11,7 @@ public class NoticeSummary {
 
     private Long postId;
 
-    private String content;
+    private String title;
 
     private String timePassed;
 }

--- a/src/main/java/space/space_spring/domain/home/adapter/in/web/SubscriptionSummary.java
+++ b/src/main/java/space/space_spring/domain/home/adapter/in/web/SubscriptionSummary.java
@@ -13,7 +13,7 @@ public class SubscriptionSummary {
 
     private String boardName;
 
-    private String boardTitle;
+    private String postTitle;
 
     private String tagName;
 }

--- a/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
+++ b/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
@@ -64,7 +64,7 @@ public class ReadHomeService implements ReadHomeUseCase {
             for (Post post : noticePosts) {
                 notices.add(new NoticeSummary(
                         post.getId(),
-                        post.getContent().getValue(),
+                        post.getTitle(),
                         ConvertCreatedDate.setCreatedDate(post.getBaseInfo().getCreatedAt())
                 ));
             }


### PR DESCRIPTION
## 📝 요약
- 홈에서 공지사항 게시판 조회 시 게시물 내용이 아닌 제목 반환
- 홈에서 구독한 게시판 조회 시 boardTitle -> postTitle 네이밍 변환

## 🔖 변경 사항

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
