### PR TITLE
Fix/#443: 태그 조회 수정

### DIFF
--- a/src/main/java/space/space_spring/domain/discord/application/service/CreatePostInDiscordService.java
+++ b/src/main/java/space/space_spring/domain/discord/application/service/CreatePostInDiscordService.java
@@ -9,7 +9,6 @@ import space.space_spring.domain.discord.application.port.out.CreateDiscordThrea
 //import space.space_spring.domain.discord.application.port.out.CreateDiscordThreadPort;
 import space.space_spring.domain.discord.application.port.out.CreateDiscordWebHookMessageCommand;
 import space.space_spring.domain.discord.application.port.out.CreateDiscordWebHookMessagePort;
-import space.space_spring.domain.post.application.port.in.Tag.LoadTagUseCase;
 import space.space_spring.domain.post.application.port.out.LoadBoardPort;
 import space.space_spring.domain.post.application.port.out.LoadTagPort;
 import space.space_spring.domain.post.domain.AttachmentType;
@@ -21,7 +20,6 @@ import space.space_spring.global.exception.CustomException;
 
 import java.util.Comparator;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.BOARD_NOT_EXIST;
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.DISCORD_THREAD_CREATE_FAIL;
@@ -83,7 +81,7 @@ public class CreatePostInDiscordService implements CreatePostInDiscordUseCase {
                                 .map(attachment->attachment.getAttachmentUrl()).toList()
                 )
                 .discordTags(
-                        loadTagPort.loadById(command.getTagIds()).stream().map(tag->tag.getDiscordId()).toList()
+                        loadTagPort.loadAllByIds(command.getTagIds()).stream().map(tag->tag.getDiscordId()).toList()
                 )
                 .build();
     }

--- a/src/main/java/space/space_spring/domain/home/adapter/in/web/SubscriptionSummary.java
+++ b/src/main/java/space/space_spring/domain/home/adapter/in/web/SubscriptionSummary.java
@@ -15,5 +15,7 @@ public class SubscriptionSummary {
 
     private String postTitle;
 
+    private Long tagId;
+
     private String tagName;
 }

--- a/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
+++ b/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
@@ -74,17 +74,18 @@ public class ReadHomeService implements ReadHomeUseCase {
         // 구독한 게시판 가져오기
         List<SubscriptionSummary> subscriptions = new ArrayList<>();
         List<Subscription> subscribedBoards = loadSubscriptionPort.loadBySpaceMember(spaceMemberId);
+        Optional<Post> latestPost;
+        String postTitle = "";
+        String tagName = "";
+
         for (Subscription subscription : subscribedBoards) {
             Board board = loadBoardPort.loadById(subscription.getBoardId());
-            Optional<Tag> tag = loadTagPort.loadByBoardId(board.getId());
+            Long tagId = subscription.getTagId();
 
-            // 각 게시판에서 제일 최신 게시물 정보 가져오기
-            Optional<Post> latestPost;
-            String postTitle = "";
-            String tagName = "";
-            if (tag.isPresent()) {
-                tagName = tag.get().getTagName();
-                latestPost = loadPostPort.loadLatestPostByBoardIdAndTagId(board.getId(), tag.get().getId());
+            if (tagId != null) {
+                Tag tag = loadTagPort.loadById(subscription.getTagId());
+                tagName = tag.getTagName();
+                latestPost = loadPostPort.loadLatestPostByBoardIdAndTagId(board.getId(), tag.getId());
                 if (latestPost.isPresent()) postTitle = latestPost.get().getTitle();
             } else {
                 latestPost = loadPostPort.loadLatestPostsByBoardIds(List.of(board.getId()), 1)

--- a/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
+++ b/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
@@ -74,11 +74,11 @@ public class ReadHomeService implements ReadHomeUseCase {
         // 구독한 게시판 가져오기
         List<SubscriptionSummary> subscriptions = new ArrayList<>();
         List<Subscription> subscribedBoards = loadSubscriptionPort.loadBySpaceMember(spaceMemberId);
-        Optional<Post> latestPost;
-        String postTitle = "";
-        String tagName = "";
-
         for (Subscription subscription : subscribedBoards) {
+            Optional<Post> latestPost;
+            String postTitle = "";
+            String tagName = "";
+
             Board board = loadBoardPort.loadById(subscription.getBoardId());
             Long tagId = subscription.getTagId();
 

--- a/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
+++ b/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
@@ -94,7 +94,7 @@ public class ReadHomeService implements ReadHomeUseCase {
                 if (latestPost.isPresent()) postTitle = latestPost.get().getTitle();
             }
 
-            subscriptions.add(new SubscriptionSummary(board.getId(), board.getBoardName(), postTitle, tagName));
+            subscriptions.add(new SubscriptionSummary(board.getId(), board.getBoardName(), postTitle, tagId, tagName));
         }
         result.addSubscription(subscriptions);
 

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/custom/PostRepositoryImpl.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/custom/PostRepositoryImpl.java
@@ -36,7 +36,8 @@ public class PostRepositoryImpl implements PostRepositoryCustom{
         return Optional.ofNullable(jpaQueryFactory.selectFrom(postJpaEntity)
                 .join(postJpaEntity.postBase, postBaseJpaEntity)
                 .join(postBaseJpaEntity.board, boardJpaEntity)
-                .join(tagJpaEntity).on(tagJpaEntity.board.eq(boardJpaEntity))
+                .join(postTagJpaEntity).on(postTagJpaEntity.postBase.eq(postBaseJpaEntity))
+                .join(tagJpaEntity).on(postTagJpaEntity.tag.eq(tagJpaEntity))
                 .where(
                         boardJpaEntity.id.eq(boardId),
                         tagJpaEntity.id.eq(tagId),

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/tag/TagPersistenceAdapter.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/tag/TagPersistenceAdapter.java
@@ -5,7 +5,6 @@ import static space.space_spring.global.common.enumStatus.BaseStatusType.ACTIVE;
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.BOARD_NOT_FOUND;
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.TAG_NOT_FOUND;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import space.space_spring.domain.post.adapter.out.persistence.board.BoardJpaEntity;
@@ -13,7 +12,6 @@ import space.space_spring.domain.post.adapter.out.persistence.board.SpringDataBo
 import space.space_spring.domain.post.application.port.out.CreateTagPort;
 import space.space_spring.domain.post.application.port.out.LoadTagPort;
 import space.space_spring.domain.post.domain.Tag;
-import space.space_spring.global.common.enumStatus.BaseStatusType;
 import space.space_spring.global.exception.CustomException;
 
 import java.util.List;
@@ -74,7 +72,7 @@ public class TagPersistenceAdapter implements LoadTagPort, CreateTagPort {
     }
 
     @Override
-    public List<Tag> loadById(List<Long> tagIds) {
+    public List<Tag> loadAllByIds(List<Long> tagIds) {
         List<TagJpaEntity> allByIdAndStatus = tagRepository.findAllByIdAndStatus(tagIds, ACTIVE);
 
         return allByIdAndStatus.stream().map(tagMapper::toDomainEntity).toList();
@@ -82,7 +80,7 @@ public class TagPersistenceAdapter implements LoadTagPort, CreateTagPort {
     }
 
     @Override
-    public Optional<Tag> loadByBoardId(Long boardId) {
-        return tagRepository.findByBoardId(boardId).map(tagMapper::toDomainEntity);
+    public Tag loadById(Long tagId) {
+        return tagRepository.findByIdAndStatus(tagId, ACTIVE).map(tagMapper::toDomainEntity).orElseThrow(() -> new CustomException(TAG_NOT_FOUND));
     }
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/out/LoadTagPort.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/out/LoadTagPort.java
@@ -1,8 +1,5 @@
 package space.space_spring.domain.post.application.port.out;
 
-import com.amazonaws.services.kms.model.ListGrantsRequest;
-import java.util.Optional;
-import space.space_spring.domain.post.domain.Board;
 import space.space_spring.domain.post.domain.Tag;
 
 import java.util.List;
@@ -16,7 +13,7 @@ public interface LoadTagPort {
 
     List<Tag> loadByDiscordId(List<Long> discordIdOfTag);
 
-    List<Tag> loadById(List<Long> tagIds);
+    List<Tag> loadAllByIds(List<Long> tagIds);
 
-    Optional<Tag> loadByBoardId(Long boardId);
+    Tag loadById(Long boardId);
 }

--- a/src/main/java/space/space_spring/domain/post/application/service/UpdatePostService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/UpdatePostService.java
@@ -78,7 +78,7 @@ public class UpdatePostService implements UpdatePostUseCase {
 
         // tag 수정
         updatePostTagPort.updatePostTag(post.getId(), command.getTagIds());
-        List<Tag> tags = loadTagPort.loadById(command.getTagIds());
+        List<Tag> tags = loadTagPort.loadAllByIds(command.getTagIds());
 
         // 6. TODO:디스코드로 게시글 수정 정보 전송
         List<String> newAttachmentUrls = new ArrayList<>();


### PR DESCRIPTION
## 📝 요약

- resolved #443 

## 🔖 변경 사항
- 하나의 게시판에 태그가 여러 개가 있는 경우에 대한 처리 추가
- 게시판 아이디 + 태그 아이디로 게시물 조회 시, 해당 게시물의 태그 정보 포함하여 조회
- 구독한 게시판 조회 시 태그 아이디 추가

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)
<img width="1399" alt="image" src="https://github.com/user-attachments/assets/55b84517-e127-4fd9-8920-7f4c6a58631c" />
로컬에서 테스트 완료했습니다.

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
