### PR TITLE
Refactor/#447/게시글 상세 조회 response 추가

### DIFF
--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/readPostDetail/ResponseOfReadPostDetail.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/readPostDetail/ResponseOfReadPostDetail.java
@@ -27,12 +27,14 @@ public class ResponseOfReadPostDetail {
 
     private Boolean isLiked;
 
+    private Boolean isPostOwner;
+
     private List<ResponseOfCommentDetail> responseOfCommentDetails;
 
     @Builder
     private ResponseOfReadPostDetail(String creatorName, String creatorProfileImageUrl, String createdAt, String lastModifiedAt,
                                      String title, String content, List<String> attachmentUrls, int likeCount, Boolean isLiked,
-                                     List<ResponseOfCommentDetail> responseOfCommentDetails) {
+                                     Boolean isPostOwner, List<ResponseOfCommentDetail> responseOfCommentDetails) {
         this.creatorName = creatorName;
         this.creatorProfileImageUrl = creatorProfileImageUrl;
         this.createdAt = createdAt;
@@ -42,6 +44,7 @@ public class ResponseOfReadPostDetail {
         this.attachmentUrls = attachmentUrls;
         this.likeCount = likeCount;
         this.isLiked = isLiked;
+        this.isPostOwner = isPostOwner;
         this.responseOfCommentDetails = responseOfCommentDetails;
     }
 
@@ -56,6 +59,7 @@ public class ResponseOfReadPostDetail {
                 .attachmentUrls(result.getAttachmentUrls())
                 .likeCount(result.getLikeCount())
                 .isLiked(result.getIsLiked())
+                .isPostOwner(result.getIsPostOwner())
                 .responseOfCommentDetails(
                         result.getInfoOfCommentDetails().stream()
                                 .map(ResponseOfCommentDetail::of)

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/readPostList/ReadPostListController.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/readPostList/ReadPostListController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import space.space_spring.domain.post.application.port.in.readPostList.ListOfPostSummary;
 import space.space_spring.domain.post.application.port.in.readPostList.ReadPostListUseCase;
+import space.space_spring.global.argumentResolver.jwtLogin.JwtLoginAuth;
 import space.space_spring.global.common.response.BaseResponse;
 
 
@@ -29,13 +30,14 @@ public class ReadPostListController {
             """)
     @GetMapping("/space/{spaceId}/board/{boardId}/post")
     public BaseResponse<ResponseOfReadPostList> readPostList(
+            @JwtLoginAuth Long spaceMemberId,
             @PathVariable Long spaceId,
             @PathVariable Long boardId,
             @RequestParam(required = false) Long tagId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("postBase.createdAt").descending());
-        ListOfPostSummary postSummaries = readPostListUseCase.readPostList(boardId, tagId, pageable);
+        ListOfPostSummary postSummaries = readPostListUseCase.readPostList(spaceMemberId, boardId, tagId, pageable);
         return new BaseResponse<>(ResponseOfReadPostList.of(postSummaries));
     }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/in/web/readPostList/ResponseOfPostSummary.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/in/web/readPostList/ResponseOfPostSummary.java
@@ -23,7 +23,10 @@ public class ResponseOfPostSummary {
 
     private String postImageUrl;
 
-    private ResponseOfPostSummary(Long postId, String title, String content, int likeCount, int commentCount, String createdAt, String creatorNickname, String postImageUrl){
+    private Boolean isPostOwner;
+
+    private ResponseOfPostSummary(Long postId, String title, String content, int likeCount, int commentCount,
+                                  String createdAt, String creatorNickname, String postImageUrl, Boolean isPostOwner){
         this.postId = postId;
         this.title = title;
         this.content = content;
@@ -32,6 +35,7 @@ public class ResponseOfPostSummary {
         this.createdAt = createdAt;
         this.creatorNickname = creatorNickname;
         this.postImageUrl = postImageUrl;
+        this.isPostOwner = isPostOwner;
     }
 
     public static ResponseOfPostSummary of(PostSummary summaryOfPost) {
@@ -43,7 +47,8 @@ public class ResponseOfPostSummary {
                 summaryOfPost.getCommentCount(),
                 ConvertCreatedDate.setCreatedDate(summaryOfPost.getCreatedAt()),
                 summaryOfPost.getCreatorNickname(),
-                summaryOfPost.getPostImageUrl()
+                summaryOfPost.getPostImageUrl(),
+                summaryOfPost.getIsPostOwner()
         );
     }
 }

--- a/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/PostQueryAdapter.java
+++ b/src/main/java/space/space_spring/domain/post/adapter/out/persistence/post/PostQueryAdapter.java
@@ -1,6 +1,5 @@
 package space.space_spring.domain.post.adapter.out.persistence.post;
 
-import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
@@ -75,7 +74,12 @@ public class PostQueryAdapter implements PostDetailQueryPort {
                                         .and(postLike.spaceMember.id.eq(spaceMemberId))
                                         .and(postLike.isLiked.eq(true))
                                         .and(postLike.status.eq(BaseStatusType.ACTIVE)))
-                                .exists()
+                                .exists(),
+                        // 스페이스 멤버가 해당 게시글 작성자인지
+                        Expressions.booleanTemplate(
+                                "CASE WHEN {0} = {1} THEN true ELSE false END",
+                                postCreator.id,
+                                spaceMemberId)
                 ))
                 .from(post)
                 .leftJoin(post.postBase, postBase)
@@ -106,6 +110,7 @@ public class PostQueryAdapter implements PostDetailQueryPort {
                 .attachmentUrls(attachmentUrls)
                 .likeCount(detail.getLikeCount())
                 .isLiked(detail.getIsLiked())
+                .isPostOwner(detail.getIsPostOwner())
                 .build();
     }
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/in/readPostDetail/ResultOfReadPostDetail.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/readPostDetail/ResultOfReadPostDetail.java
@@ -29,5 +29,7 @@ public class ResultOfReadPostDetail {
 
     private Boolean isLiked;
 
+    private Boolean isPostOwner;
+
     private List<InfoOfCommentDetail> infoOfCommentDetails;
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/in/readPostList/PostSummary.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/readPostList/PostSummary.java
@@ -24,7 +24,10 @@ public class PostSummary {
 
     private String postImageUrl;
 
-    private PostSummary(Long postId, String title, Content content, int likeCount, int commentCount, LocalDateTime createdAt, String creatorNickname, String postImageUrl) {
+    private Boolean isPostOwner;
+
+    private PostSummary(Long postId, String title, Content content, int likeCount, int commentCount,
+                        LocalDateTime createdAt, String creatorNickname, String postImageUrl, Boolean isPostOwner) {
         this.postId = postId;
         this.title = title;
         this.content = content;
@@ -33,9 +36,11 @@ public class PostSummary {
         this.createdAt = createdAt;
         this.creatorNickname = creatorNickname;
         this.postImageUrl = postImageUrl;
+        this.isPostOwner = isPostOwner;
     }
 
-    public static PostSummary of(Long postId, String title, Content content, int likeCount, int commentCount, LocalDateTime createdAt, String creatorNickname, String postImageUrl) {
-        return new PostSummary(postId, title, content, likeCount, commentCount, createdAt, creatorNickname, postImageUrl);
+    public static PostSummary of(Long postId, String title, Content content, int likeCount, int commentCount,
+                                 LocalDateTime createdAt, String creatorNickname, String postImageUrl, Boolean isPostOwner) {
+        return new PostSummary(postId, title, content, likeCount, commentCount, createdAt, creatorNickname, postImageUrl, isPostOwner);
     }
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/in/readPostList/ReadPostListUseCase.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/in/readPostList/ReadPostListUseCase.java
@@ -4,5 +4,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface ReadPostListUseCase {
 
-    ListOfPostSummary readPostList(Long boardId, Long tagId, Pageable pageable);
+    ListOfPostSummary readPostList(Long spaceMemberId, Long boardId, Long tagId, Pageable pageable);
 }

--- a/src/main/java/space/space_spring/domain/post/application/port/out/post/PostDetailView.java
+++ b/src/main/java/space/space_spring/domain/post/application/port/out/post/PostDetailView.java
@@ -28,11 +28,13 @@ public class PostDetailView {
 
     private Boolean isLiked;
 
+    private Boolean isPostOwner;
+
     // Querydsl에서 사용할 생성자
     public PostDetailView(String creatorName, String creatorProfileImageUrl,
                           LocalDateTime createdAt, LocalDateTime lastModifiedAt,
                           String title, String content, List<String> attachmentUrls,
-                          Long likeCount, Boolean isLiked) {
+                          Long likeCount, Boolean isLiked, Boolean isPostOwner) {
         this.creatorName = creatorName;
         this.creatorProfileImageUrl = creatorProfileImageUrl;
         this.createdAt = createdAt;
@@ -42,5 +44,6 @@ public class PostDetailView {
         this.attachmentUrls = attachmentUrls;
         this.likeCount = likeCount;
         this.isLiked = isLiked;
+        this.isPostOwner = isPostOwner;
     }
 }

--- a/src/main/java/space/space_spring/domain/post/application/service/ReadPostDetailService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/ReadPostDetailService.java
@@ -63,6 +63,7 @@ public class ReadPostDetailService implements ReadPostDetailUseCase {
                 .attachmentUrls(postDetailView.getAttachmentUrls())
                 .likeCount(postDetailView.getLikeCount().intValue())
                 .isLiked(postDetailView.getIsLiked())
+                .isPostOwner(postDetailView.getIsPostOwner())
                 .infoOfCommentDetails(mapToInfoOfCommentDetails(processedCommentDetailViews))
                 .build();
     }

--- a/src/main/java/space/space_spring/domain/post/application/service/ReadPostListService.java
+++ b/src/main/java/space/space_spring/domain/post/application/service/ReadPostListService.java
@@ -23,6 +23,7 @@ import space.space_spring.global.util.NaturalNumber;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static space.space_spring.global.common.response.status.BaseExceptionResponseStatus.TAG_IS_REQUIRED_FOR_THIS_BOARD;
 
@@ -40,7 +41,7 @@ public class ReadPostListService implements ReadPostListUseCase {
     private final LoadSpaceMemberInfoPort loadSpaceMemberInfoPort;
 
     @Override
-    public ListOfPostSummary readPostList(Long boardId, Long tagId, Pageable pageable) {
+    public ListOfPostSummary readPostList(Long spaceMemberId, Long boardId, Long tagId, Pageable pageable) {
         // 1. Board 조회
         Board board = loadBoardPort.loadById(boardId);
 
@@ -83,7 +84,8 @@ public class ReadPostListService implements ReadPostListUseCase {
                         commentCounts.getOrDefault(post.getId(), NaturalNumber.of(0)).getNumber(),
                         post.getBaseInfo().getCreatedAt(),
                         creatorNicknames.getOrDefault(post.getPostCreatorId(), "알 수 없음"),
-                        thumbnailImages.getOrDefault(post.getId(), null)
+                        thumbnailImages.getOrDefault(post.getId(), null),
+                        post.getPostCreatorId().equals(spaceMemberId)
                 )).toList();
 
         // 9. ListOfPostSummary 생성


### PR DESCRIPTION
## 📝 요약
resolved : #447 

## 🔖 변경 사항
1. 게시글 상세조회 api ("/space/{spaceId}/board/{boardId}/post/{postId}") 의 response에 요청 보내는 유저가 해당 게시글의 작성자인지를 알려주는 정보 추가

2. 게시글 리스트 조회 api ("/space/{spaceId}/board/{boardId}/post") 의 response에 요청 보내는 유저가 해당 게시글의 작성자인지를 알려주는 정보 추가

## ✅ 리뷰 요구사항
<로컬 테스트 해보다가 알게된 사실>
현재 S3 upload 시에 업로드 할 수있는 파일 확장자를 `AllowedImageFileExtensions.java` enum 파일에 명시해 둔 상황
<img width="400" alt="image" src="https://github.com/user-attachments/assets/91e09bcd-fe28-4410-a5b1-3f783365c73a" />

그런데 제가 HEIC 이미지 파일을 첨부파일로 해서 게시글 생성 요청을 보내니, 디스코드에 제대로 보이지 않습니다
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/55e16118-0a20-4108-9680-2e55386c1f22" />

-> 이런식으로 미리보기가 안됨 (링크 클릭하면 사진이 현재 디바이스에 다운로드 되고, 저장된 사진을 클릭하면 보이긴 함)
-> 위 사진은 jpeg 파일임 -> 미리보기 잘됨

개인적인 추측으로는 heic 파일이 용량이 커서 그런가? 싶긴한데 정확한 이유를 잘 모르겠네여. (구글링 해봐도 잘 안나오네여)
혹시 관련해서 아는 내용 있으시면 리뷰 남겨주시면 감사하겠습니다

## 📸 확인 방법 (선택)
<img width="1626" alt="image" src="https://github.com/user-attachments/assets/e6b56ccc-e876-497f-9985-856d11f4ab5b" />
-> 변경사항 1  로컬 테스트 결과

<img width="1619" alt="image" src="https://github.com/user-attachments/assets/36fff989-316f-46d3-a527-d46df5c186ec" />
-> 변경사항 2 로컬 테스트 결과

로컬로는 전부 제가 글 생성하고 제가 확인하는 거여서 isPostOwner 값이 전부 true긴 합니다. dev로 배포 후 한번 확인이 필요하긴 합니다.

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
