### PR TITLE
Feat/#450: 홈 조회 시 공지사항 게시판 아이디 추가

### DIFF
--- a/src/main/java/space/space_spring/domain/home/adapter/in/web/NoticeSummary.java
+++ b/src/main/java/space/space_spring/domain/home/adapter/in/web/NoticeSummary.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class NoticeSummary {
 
+    private Long boardId;
+
     private Long postId;
 
     private String title;

--- a/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
+++ b/src/main/java/space/space_spring/domain/home/application/service/ReadHomeService.java
@@ -63,6 +63,7 @@ public class ReadHomeService implements ReadHomeUseCase {
 
             for (Post post : noticePosts) {
                 notices.add(new NoticeSummary(
+                        post.getBoardId(),
                         post.getId(),
                         post.getTitle(),
                         ConvertCreatedDate.setCreatedDate(post.getBaseInfo().getCreatedAt())


### PR DESCRIPTION
## 📝 요약

- resolved #450 

## 🔖 변경 사항
홈 조회 응답에 공지사항 게시판의 boardId 추가 (공지사항 게시판의 경우 태그는 해당이 없기 때문에 따로 추가 x)

## ✅ 리뷰 요구사항

## 📸 확인 방법 (선택)

<br/>

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요

    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
